### PR TITLE
Update: 소셜로그인 실패(이미 자체회원가입)한 경우 쿠키 전송

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/oauth/OAuth2FailureHandler.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/oauth/OAuth2FailureHandler.java
@@ -9,9 +9,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-import org.springframework.security.web.savedrequest.RequestCache;
-import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
@@ -19,12 +16,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static kr.ac.kumoh.illdang100.tovalley.util.CustomResponseUtil.addCookie;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-    private String DEFAULT_URL = "http://localhost:3000";
+
+    private final String cookieName = "social_login_error";
+    private final String cookieValue = "email_already_registered";
+    private final String DEFAULT_URL = "http://localhost:3000";
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -39,6 +41,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
             errorMessage = "인증 실패";
         }
 
+        addCookie(response, cookieName, cookieValue, false);
         resultRedirectStrategy(request, response);
         CustomResponseUtil.fail(response, errorMessage, HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
- 사용자에게 이미 자체 회원가입된 회원임을 알리기 위해 쿠키로 에러 내용 전달함 
-> 로그인 페이지로 리다이렉트된 다음 alert창 뜨고 나서 쿠키 값 삭제됨