### PR TITLE
refactor: refresh token 발급 및 재발급 코드 리팩토링

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/handler/CustomExceptionHandler.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/handler/CustomExceptionHandler.java
@@ -5,6 +5,7 @@ import kr.ac.kumoh.illdang100.tovalley.handler.ex.CustomApiException;
 import kr.ac.kumoh.illdang100.tovalley.handler.ex.CustomValidationException;
 import kr.ac.kumoh.illdang100.tovalley.handler.ex.OpenApiException;
 import kr.ac.kumoh.illdang100.tovalley.handler.ex.SuspensionException;
+import kr.ac.kumoh.illdang100.tovalley.handler.ex.UnauthorizedAccessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,13 @@ public class CustomExceptionHandler {
 
         log.error(e.getMessage());
         return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<?> reIssueTokenException(UnauthorizedAccessException e) {
+
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(SuspensionException.class)

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/handler/ex/UnauthorizedAccessException.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/handler/ex/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package kr.ac.kumoh.illdang100.tovalley.handler.ex;
+
+public class UnauthorizedAccessException extends RuntimeException {
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtProcess.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtProcess.java
@@ -41,11 +41,12 @@ public class JwtProcess {
         return JwtVO.TOKEN_PREFIX + URLEncoder.encode(jwtToken, StandardCharsets.UTF_8);
     }
 
-    public String createRefreshToken(String memberId, String role, String ip) {
+    public String createRefreshToken(String id, String memberId, String role, String ip) {
         String refreshToken = JWT.create()
                 .withSubject(jwtSubject)
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.REFRESH_TOKEN_EXPIRATION_TIME))
-                .withClaim("id", memberId)
+                .withClaim("id", id)
+                .withClaim("memberId", memberId)
                 .withClaim("role", role)
                 .withClaim("ip", ip)
                 .sign(Algorithm.HMAC512(secret));
@@ -53,8 +54,7 @@ public class JwtProcess {
         return JwtVO.TOKEN_PREFIX + URLEncoder.encode(refreshToken, StandardCharsets.UTF_8);
     }
 
-
-    public PrincipalDetails verify (String token) {
+    public PrincipalDetails verify(String token) {
         DecodedJWT decodedJWT = isSatisfiedToken(token);
 
         Long id = decodedJWT.getClaim("id").asLong();

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtVO.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtVO.java
@@ -1,9 +1,10 @@
 package kr.ac.kumoh.illdang100.tovalley.security.jwt;
 
 public interface JwtVO {
-    public static final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 30; // 30분
+    // TODO: 만료시간 30분에서 1분
+    public static final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 1; // 30분
     public static final int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14; // 2주
     public static final String TOKEN_PREFIX = "Bearer ";
-    public static final String ACCESS_TOKEN = "accessToken";
-    public static final String REFRESH_TOKEN = "refreshToken";
+    public static final String ACCESS_TOKEN = "ACCESSTOKEN";
+    public static final String REFRESH_TOKEN = "REFRESHTOKENID";
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtVO.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtVO.java
@@ -1,8 +1,7 @@
 package kr.ac.kumoh.illdang100.tovalley.security.jwt;
 
 public interface JwtVO {
-    // TODO: 만료시간 30분에서 1분
-    public static final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 1; // 30분
+    public static final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 30; // 30분
     public static final int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14; // 2주
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String ACCESS_TOKEN = "ACCESSTOKEN";

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshToken.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshToken.java
@@ -18,12 +18,10 @@ public class RefreshToken {
     @Id
     private String id;
 
+    private String memberId;
     private String role;
-
     private String ip;
 
     @Indexed
     private String refreshToken;
-
-    public void changeRefreshToken(String refreshToken) {this.refreshToken = refreshToken;}
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshToken.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshToken.java
@@ -21,7 +21,5 @@ public class RefreshToken {
     private String memberId;
     private String role;
     private String ip;
-
-    @Indexed
     private String refreshToken;
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshTokenRedisRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshTokenRedisRepository.java
@@ -2,8 +2,5 @@ package kr.ac.kumoh.illdang100.tovalley.security.jwt;
 
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.Optional;
-
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
-    Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.illdang100.tovalley.security.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.dto.member.MemberReqDto.LoginReqDto;
 import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
@@ -36,7 +37,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     private RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtProcess jwtProcess, RefreshTokenRedisRepository refreshTokenRedisRepository) {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtProcess jwtProcess,
+                                   RefreshTokenRedisRepository refreshTokenRedisRepository) {
         super(authenticationManager);
         setFilterProcessesUrl("/api/login");
         this.authenticationManager = authenticationManager;
@@ -45,7 +47,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     }
 
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
         try {
 
             ObjectMapper om = new ObjectMapper();
@@ -64,20 +67,25 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     }
 
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
         CustomResponseUtil.fail(response, "로그인 실패", HttpStatus.BAD_REQUEST);
     }
 
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+                                            Authentication authResult) throws IOException, ServletException {
         PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
 
         String accessToken = jwtProcess.createAccessToken(principalDetails);
 
         String ip = getClientIpAddress(request);
-        String refreshToken = saveRefreshToken(jwtProcess, refreshTokenRedisRepository, principalDetails.getMember(), ip);
+        Member member = principalDetails.getMember();
+        String refreshTokenId = saveRefreshToken(jwtProcess, refreshTokenRedisRepository,
+                String.valueOf(member.getId()),
+                member.getRole().toString(), ip);
         addCookie(response, JwtVO.ACCESS_TOKEN, accessToken);
-        addCookie(response, JwtVO.REFRESH_TOKEN, refreshToken);
+        addCookie(response, JwtVO.REFRESH_TOKEN, refreshTokenId);
         addCookie(response, ISLOGIN, "true", false);
 
         CustomResponseUtil.success(response, null);

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/filter/JwtAuthorizationFilter.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/filter/JwtAuthorizationFilter.java
@@ -2,11 +2,13 @@ package kr.ac.kumoh.illdang100.tovalley.security.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.kumoh.illdang100.tovalley.dto.ResponseDto;
+import kr.ac.kumoh.illdang100.tovalley.handler.ex.UnauthorizedAccessException;
 import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtVO;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.RefreshToken;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.RefreshTokenRedisRepository;
+import kr.ac.kumoh.illdang100.tovalley.util.HttpServletUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -24,6 +26,7 @@ import java.io.IOException;
 import static kr.ac.kumoh.illdang100.tovalley.util.CookieUtil.*;
 import static kr.ac.kumoh.illdang100.tovalley.util.CustomResponseUtil.*;
 import static kr.ac.kumoh.illdang100.tovalley.util.EntityFinder.findRefreshTokenOrElseThrowEx;
+import static kr.ac.kumoh.illdang100.tovalley.util.TokenUtil.saveRefreshToken;
 
 @Slf4j
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
@@ -32,23 +35,25 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     private RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtProcess jwtProcess, RefreshTokenRedisRepository refreshTokenRedisRepository) {
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtProcess jwtProcess,
+                                  RefreshTokenRedisRepository refreshTokenRedisRepository) {
         super(authenticationManager);
         this.jwtProcess = jwtProcess;
         this.refreshTokenRedisRepository = refreshTokenRedisRepository;
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
         String requestUrl = request.getRequestURL().toString();
         boolean containsApiAuth = requestUrl.contains("/api/auth/");
         boolean containsAdmin = requestUrl.contains("/th/admin/");
         if ((containsApiAuth || containsAdmin) && isCookieVerify(request, JwtVO.ACCESS_TOKEN)) {
-            String token = findCookieValue(request, JwtVO.ACCESS_TOKEN).replace(JwtVO.TOKEN_PREFIX, "");
-            log.debug("accessToken={}", token);
+            String accessToken = findCookieValue(request, JwtVO.ACCESS_TOKEN).replace(JwtVO.TOKEN_PREFIX, "");
+            log.debug("accessToken={}", accessToken);
 
             try {
-                PrincipalDetails loginMember = jwtProcess.verify(token);
+                PrincipalDetails loginMember = jwtProcess.verify(accessToken);
 
                 Authentication authentication = new UsernamePasswordAuthenticationToken(
                         loginMember, null, loginMember.getAuthorities()
@@ -64,31 +69,42 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     }
 
     private void reIssueToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        if (isCookieVerify(request, JwtVO.REFRESH_TOKEN)) {
-            String refreshToken = findCookieValue(request, JwtVO.REFRESH_TOKEN);
-            String jwtToken = refreshToken.replace(JwtVO.TOKEN_PREFIX, "");
-
-            // 리프레시 토큰 유효성 검사
-            try {
-                jwtProcess.isSatisfiedToken(jwtToken);
-            } catch (Exception e) {
-                handleTokenVerificationFailure(response);
-                return;
-            }
-
-            RefreshToken findRefreshToken
-                    = findRefreshTokenOrElseThrowEx(refreshTokenRedisRepository, refreshToken);
-
-            // 토큰 재발급
-            String memberId = findRefreshToken.getId();
-            String memberRole = findRefreshToken.getRole();
-
-            String newAccessToken = jwtProcess.createNewAccessToken(Long.valueOf(memberId), memberRole);
-            log.debug("[토큰 재발급]accessToken={}", newAccessToken);
-
-            // 토큰을 쿠키에 추가
-            addCookie(response, JwtVO.ACCESS_TOKEN, newAccessToken);
+        if (!isCookieVerify(request, JwtVO.REFRESH_TOKEN)) {
+            return;
         }
+        String refreshTokenId = findCookieValue(request, JwtVO.REFRESH_TOKEN);
+        RefreshToken findRefreshToken = findRefreshTokenOrElseThrowEx(refreshTokenRedisRepository, refreshTokenId);
+        validateToken(request, response, findRefreshToken);
+    }
+
+    private void validateToken(HttpServletRequest request, HttpServletResponse response, RefreshToken findRefreshToken)
+            throws IOException {
+        String jwtToken = findRefreshToken.getRefreshToken().replace(JwtVO.TOKEN_PREFIX, "");
+        String clientIpAddress = HttpServletUtil.getClientIpAddress(request);
+        try {
+            jwtProcess.isSatisfiedToken(jwtToken);
+            validateIpAddress(findRefreshToken, clientIpAddress);
+        } catch (Exception e) {
+            handleTokenVerificationFailure(response);
+        }
+        reIssueNewToken(response, findRefreshToken, clientIpAddress);
+    }
+
+    private void validateIpAddress(RefreshToken findRefreshToken, String clientIpAddress) {
+        if (!findRefreshToken.getIp().equals(clientIpAddress)) {
+            throw new UnauthorizedAccessException("다른 IP에서의 접근이 감지되었습니다. 보안을 위해 접속이 종료됩니다.");
+        }
+    }
+
+    private void reIssueNewToken(HttpServletResponse response, RefreshToken findRefreshToken, String clientIpAddress) {
+        String memberId = findRefreshToken.getMemberId();
+        String memberRole = findRefreshToken.getRole();
+        String newAccessToken = jwtProcess.createNewAccessToken(Long.valueOf(memberId), memberRole);
+        refreshTokenRedisRepository.delete(findRefreshToken);
+        String newRefreshTokenId = saveRefreshToken(jwtProcess, refreshTokenRedisRepository,
+                memberId, memberRole, clientIpAddress);
+        addCookie(response, JwtVO.ACCESS_TOKEN, newAccessToken);
+        addCookie(response, JwtVO.REFRESH_TOKEN, newRefreshTokenId);
     }
 
     private void handleTokenVerificationFailure(HttpServletResponse response) throws IOException {

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/oauth/OAuth2SuccessHandler.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/security/oauth/OAuth2SuccessHandler.java
@@ -31,7 +31,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProcess jwtProcess;
 
-    private  final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -44,10 +44,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtProcess.createAccessToken(principalDetails);
 
         String ip = getClientIpAddress(request);
-        String refreshToken = saveRefreshToken(jwtProcess, refreshTokenRedisRepository, member, ip);
+        String refreshTokenId = saveRefreshToken(jwtProcess, refreshTokenRedisRepository,
+                String.valueOf(member.getId()),
+                member.getRole().toString(), ip);
 
         addCookie(response, JwtVO.ACCESS_TOKEN, accessToken);
-        addCookie(response, JwtVO.REFRESH_TOKEN, refreshToken);
+        addCookie(response, JwtVO.REFRESH_TOKEN, refreshTokenId);
         addCookie(response, ISLOGIN, "true", false);
 
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberService.java
@@ -30,7 +30,7 @@ public interface MemberService {
     MemberProfileRespDto getMemberDetail(Long memberId);
 
     // 사용자 로그아웃 - 리프래시 토큰 삭제
-    void logout(HttpServletResponse response, String refreshToken);
+    void logout(HttpServletResponse response, String refreshTokenId);
 
     // 사용자 닉네임 업데이트
     void updateMemberNick(Long memberId, String newNickname);

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImpl.java
@@ -124,8 +124,8 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void logout(HttpServletResponse response, String refreshToken) {
-        deleteRefreshToken(refreshToken);
+    public void logout(HttpServletResponse response, String refreshTokenId) {
+        deleteRefreshToken(refreshTokenId);
         expireCookie(response, JwtVO.ACCESS_TOKEN);
         expireCookie(response, JwtVO.REFRESH_TOKEN);
         addCookie(response, ISLOGIN, "false", false);
@@ -138,8 +138,8 @@ public class MemberServiceImpl implements MemberService {
         response.addCookie(cookie);
     }
 
-    private void deleteRefreshToken(String refreshToken) {
-        Optional<RefreshToken> refreshTokenOpt = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
+    private void deleteRefreshToken(String refreshTokenId) {
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenRedisRepository.findById(refreshTokenId);
         if (refreshTokenOpt.isPresent()) {
             RefreshToken findRefreshToken = refreshTokenOpt.get();
             refreshTokenRedisRepository.delete(findRefreshToken);

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/CookieUtil.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/CookieUtil.java
@@ -28,8 +28,15 @@ public class CookieUtil {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 String cookieValue = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
-                if (cookie.getName().equals(cookieName) && cookieValue.startsWith(JwtVO.TOKEN_PREFIX)) {
-                    return true;
+                if (cookie.getName().equals(cookieName)) {
+                    // access token이나 refresh token이라면 검증에 성공했다고 판단
+                    if (cookieName.equals(JwtVO.ACCESS_TOKEN) && cookieValue.startsWith(JwtVO.TOKEN_PREFIX)) {
+                        return true;
+                    }
+                    // refreshTokenId는 특정 prefix 없이 바로 검증에 성공했다고 판단
+                    else if (cookieName.equals(JwtVO.REFRESH_TOKEN)) {
+                        return true;
+                    }
                 }
             }
         }
@@ -37,15 +44,22 @@ public class CookieUtil {
     }
 
     public static String findCookieValue(HttpServletRequest request, String cookieName) {
-        String token = "";
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            String cookieValue = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
-            if (cookie.getName().equals(cookieName) && cookieValue.startsWith(JwtVO.TOKEN_PREFIX)) {
-                token = cookieValue;
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                String cookieValue = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
+                if (cookie.getName().equals(cookieName)) {
+                    // access token이라면 TOKEN_PREFIX를 제거한 후 반환
+                    if (cookieName.equals(JwtVO.ACCESS_TOKEN) && cookieValue.startsWith(JwtVO.TOKEN_PREFIX)) {
+                        return cookieValue.replace(JwtVO.TOKEN_PREFIX, "");
+                    }
+                    // refreshTokenId라면 바로 반환
+                    else if (cookieName.equals(JwtVO.REFRESH_TOKEN)) {
+                        return cookieValue;
+                    }
+                }
             }
         }
-        return token;
+        return "";
     }
-
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
@@ -50,8 +50,9 @@ public class EntityFinder {
                 .orElseThrow(() -> new CustomApiException("사용자[" + email + "]가 존재하지 않습니다"));
     }
 
-    public static RefreshToken findRefreshTokenOrElseThrowEx(RefreshTokenRedisRepository refreshTokenRedisRepository, String refreshToken) {
-        return refreshTokenRedisRepository.findByRefreshToken(refreshToken)
+    public static RefreshToken findRefreshTokenOrElseThrowEx(RefreshTokenRedisRepository refreshTokenRedisRepository,
+                                                             String refreshTokenId) {
+        return refreshTokenRedisRepository.findById(refreshTokenId)
                 .orElseThrow(() -> new CustomApiException("토큰 갱신에 실패했습니다"));
     }
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/TokenUtil.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/TokenUtil.java
@@ -1,24 +1,30 @@
 package kr.ac.kumoh.illdang100.tovalley.util;
 
+import java.util.UUID;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.RefreshToken;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.RefreshTokenRedisRepository;
 
 public class TokenUtil {
-    public static String saveRefreshToken(JwtProcess jwtProcess, RefreshTokenRedisRepository refreshTokenRedisRepository, Member member, String ip) {
-        String memberId = member.getId().toString();
-        String role = member.getRole().toString();
+    public static String saveRefreshToken(JwtProcess jwtProcess,
+                                          RefreshTokenRedisRepository refreshTokenRedisRepository,
+                                          String memberId,
+                                          String memberRole,
+                                          String ip) {
 
-        String refreshToken = jwtProcess.createRefreshToken(memberId, role, ip);
+        String refreshTokenId = UUID.randomUUID().toString();
+
+        String refreshToken = jwtProcess.createRefreshToken(refreshTokenId, memberId, memberRole, ip);
 
         refreshTokenRedisRepository.save(RefreshToken.builder()
-                .id(memberId)
-                .role(role)
+                .id(refreshTokenId)
+                .memberId(memberId)
+                .role(memberRole)
                 .ip(ip)
                 .refreshToken(refreshToken)
                 .build());
 
-        return refreshToken;
+        return refreshTokenId;
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/MemberApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/MemberApiController.java
@@ -70,9 +70,9 @@ public class MemberApiController {
     }
 
     @DeleteMapping(value = "/logout")
-    public ResponseEntity<?> logout(@CookieValue(JwtVO.REFRESH_TOKEN) String refreshToken,
+    public ResponseEntity<?> logout(@CookieValue(JwtVO.REFRESH_TOKEN) String refreshTokenId,
                                     HttpServletResponse response) {
-        memberService.logout(response, refreshToken);
+        memberService.logout(response, refreshTokenId);
 
         return new ResponseEntity<>(new ResponseDto<>(1, "로그아웃을 성공했습니다", null), HttpStatus.OK);
     }

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtAuthenticationFilterTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtAuthenticationFilterTest.java
@@ -71,9 +71,9 @@ public class JwtAuthenticationFilterTest extends DummyObject {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 String cookieValue = cookie.getValue();
-                if (cookie.getName().equals("accessToken")) {
+                if (cookie.getName().equals("ACCESSTOKEN")) {
                     accessToken = URLDecoder.decode(cookieValue, StandardCharsets.UTF_8);
-                } else if (cookie.getName().equals("refreshToken")) {
+                } else if (cookie.getName().equals("REFRESHTOKENID")) {
                     refreshToken = URLDecoder.decode(cookieValue, StandardCharsets.UTF_8);
                 }
             }
@@ -82,7 +82,6 @@ public class JwtAuthenticationFilterTest extends DummyObject {
         resultActions.andExpect(status().isOk());
         assertThat(accessToken).isNotNull();
         assertThat(accessToken.startsWith(JwtVO.TOKEN_PREFIX)).isTrue();
-        assertThat(refreshToken.startsWith(JwtVO.TOKEN_PREFIX)).isTrue();
     }
 
     @Test

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtAuthorizationFilterTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtAuthorizationFilterTest.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.illdang100.tovalley.security.jwt;
 
+import java.util.UUID;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberEnum;
 import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
@@ -43,9 +44,11 @@ public class JwtAuthorizationFilterTest extends DummyObject {
                 .role(MemberEnum.CUSTOMER)
                 .build();
 
+        String refreshTokenId = UUID.randomUUID().toString();
         PrincipalDetails loginUser = new PrincipalDetails(member);
         String accessToken = jwtProcess.createAccessToken(loginUser);
-        String refreshToken = jwtProcess.createRefreshToken(member.getId().toString(), member.getRole().toString(), "127.0.0.1");
+        String refreshToken = jwtProcess.createRefreshToken(refreshTokenId, member.getId().toString(),
+                member.getRole().toString(), "127.0.0.1");
 
         String decodedAccessToken = URLDecoder.decode(accessToken, StandardCharsets.UTF_8);
         String decodedRefreshToken = URLDecoder.decode(refreshToken, StandardCharsets.UTF_8);
@@ -84,8 +87,10 @@ public class JwtAuthorizationFilterTest extends DummyObject {
                 .build();
 
         PrincipalDetails loginUser = new PrincipalDetails(member);
+        String refreshTokenId = UUID.randomUUID().toString();
         String accessToken = jwtProcess.createAccessToken(loginUser);
-        String refreshToken = jwtProcess.createRefreshToken(member.getId().toString(), member.getRole().toString(), "127.0.0.1");
+        String refreshToken = jwtProcess.createRefreshToken(refreshTokenId, member.getId().toString(),
+                member.getRole().toString(), "127.0.0.1");
 
         String decodedAccessToken = URLDecoder.decode(accessToken, StandardCharsets.UTF_8);
         String decodedRefreshToken = URLDecoder.decode(refreshToken, StandardCharsets.UTF_8);

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtProcessTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/JwtProcessTest.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.illdang100.tovalley.security.jwt;
 
+import java.util.UUID;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberEnum;
 import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
@@ -28,6 +29,7 @@ class JwtProcessTest extends DummyObject {
 
         return jwtProcess.createAccessToken(principalDetails);
     }
+
     @Test
     @DisplayName("액세스 토큰 생성 테스트")
     void createAccessToken_test() throws Exception {
@@ -51,8 +53,11 @@ class JwtProcessTest extends DummyObject {
         //given
 
         //when
-        String refreshToken1 = jwtProcess.createRefreshToken("1", MemberEnum.CUSTOMER.toString(), "127.0.0.1");
-        String refreshToken2 = jwtProcess.createRefreshToken("2", MemberEnum.ADMIN.toString(), "127.0.0.1");
+        String refreshTokenId = UUID.randomUUID().toString();
+        String refreshToken1 = jwtProcess.createRefreshToken(refreshTokenId, "1", MemberEnum.CUSTOMER.toString(),
+                "127.0.0.1");
+        String refreshToken2 = jwtProcess.createRefreshToken(refreshTokenId, "2", MemberEnum.ADMIN.toString(),
+                "127.0.0.1");
 
         String decodedRefreshToken1 = URLDecoder.decode(refreshToken1, StandardCharsets.UTF_8);
         String decodedRefreshToken2 = URLDecoder.decode(refreshToken2, StandardCharsets.UTF_8);

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshTokenRedisRepositoryTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/security/jwt/RefreshTokenRedisRepositoryTest.java
@@ -31,7 +31,7 @@ public class RefreshTokenRedisRepositoryTest {
         //when
         refreshTokenRedisRepository.save(refreshToken);
 
-        Optional<RefreshToken> findTokenOpt = refreshTokenRedisRepository.findByRefreshToken("testRefreshToken");
+        Optional<RefreshToken> findTokenOpt = refreshTokenRedisRepository.findById("testId");
 
         RefreshToken findToken = findTokenOpt.get();
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImplTest.java
@@ -95,7 +95,7 @@ class MemberServiceImplTest extends DummyObject {
         RefreshToken refreshToken = newRefreshToken("testRefreshToken");
 
         //stub
-        when(refreshTokenRedisRepository.findByRefreshToken(any())).thenReturn(Optional.of(refreshToken));
+        when(refreshTokenRedisRepository.findById(any())).thenReturn(Optional.of(refreshToken));
 
         //when
         memberService.logout(response, "testRefreshToken");


### PR DESCRIPTION
**문제 상황**
:  A라는 사람이 로그인 후에 accessToken과 refreshToken을 쿠키로 발급 받는다. 그리고 B라는 사람이 A의 refreshToken을 탈취한 후 자신의 쿠키에 임의의 accessToken과 탈취한 refreshToken을 추가한다. 그리고 B가 인증이 필요한 페이지를 요청하면, 서버에서 refreshToken을 확인하고 accessToken을 재발급해준다.
-> 보안상 매우 취약하다.

**해결 전략**
- 기존에는 사용자 웹 브라우저에 쿠키로 refresh token 자체를 저장하였다. -> refresh token의 ID를 저장하는 방식으로 변경
- refresh token의 필드로 사용자 ip 주소를 추가해서, 토큰 재발급 시 해당 ip 주소와 요청한 사용자의 ip 주소를 비교해서 작업을 수행한다.

========================================================================================
이외에도 다른 작업 수행
- UnauthorizedAccessException 예외 클래스 생성
- 쿠키에 들어가는 토큰명 변경
  - accessToken -> ACCESSTOKEN
  - refreshToken -> REFRESHTOKENID
- 토큰 재발급 코드 리팩토링