### PR TITLE
feature: 관리자용 사용자 조회 기능 구현

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Optional<Member> findByUsername(String username);
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryCustom.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package kr.ac.kumoh.illdang100.tovalley.domain.member;
+
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface MemberRepositoryCustom {
+
+    Slice<SearchMembersRespDto> findSliceMembersByNickname(String nickname, Pageable pageable);
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImpl.java
@@ -1,0 +1,65 @@
+package kr.ac.kumoh.illdang100.tovalley.domain.member;
+
+import static kr.ac.kumoh.illdang100.tovalley.domain.member.QMember.member;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import javax.persistence.EntityManager;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Slice<SearchMembersRespDto> findSliceMembersByNickname(String nickname, Pageable pageable) {
+
+        JPAQuery<SearchMembersRespDto> query = queryFactory
+                .select(Projections.constructor(SearchMembersRespDto.class,
+                        member.id,
+                        member.email,
+                        member.memberName,
+                        member.nickname,
+                        member.role))
+                .from(member)
+                .where(searchNicknameEquals(nickname))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1);
+
+        for (Sort.Order o : pageable.getSort()) {
+            PathBuilder pathBuilder = new PathBuilder(
+                    member.getType(), member.getMetadata()
+            );
+            query.orderBy(new OrderSpecifier(o.isAscending() ? Order.ASC : Order.DESC,
+                    pathBuilder.get(o.getProperty())));
+        }
+
+        List<SearchMembersRespDto> result = query.fetch();
+
+        boolean hasNext = false;
+        if (result.size() > pageable.getPageSize()) {
+            result.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    private BooleanExpression searchNicknameEquals(String nickname) {
+        return (nickname == null) ? null : member.nickname.eq(nickname);
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/admin/AdminChangeRoleReqDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/admin/AdminChangeRoleReqDto.java
@@ -1,11 +1,14 @@
 package kr.ac.kumoh.illdang100.tovalley.dto.admin;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-@Getter
-@Setter
-@NoArgsConstructor
 public class AdminChangeRoleReqDto {
+
+    @AllArgsConstructor
+    @Data
+    public static class SearchMembersCondition {
+
+        private String nickname;
+    }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/admin/AdminChangeRoleRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/admin/AdminChangeRoleRespDto.java
@@ -1,5 +1,7 @@
 package kr.ac.kumoh.illdang100.tovalley.dto.admin;
 
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberEnum;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,4 +10,22 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AdminChangeRoleRespDto {
+
+    @Data
+    public static class SearchMembersRespDto {
+
+        private Long id;
+        private String email;
+        private String memberName;
+        private String nickname;
+        private String role; // ADMIN, CUSTOMER
+
+        public SearchMembersRespDto(Long id, String email, String memberName, String nickname, MemberEnum role) {
+            this.id = id;
+            this.email = email;
+            this.memberName = memberName;
+            this.nickname = nickname;
+            this.role = role.toString();
+        }
+    }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberService.java
@@ -1,6 +1,9 @@
 package kr.ac.kumoh.illdang100.tovalley.service.member;
 
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
@@ -39,4 +42,6 @@ public interface MemberService {
 
     // 회원 탈퇴
     void deleteMember(Long memberId, String refreshToken);
+
+    Slice<SearchMembersRespDto> searchMembers(String nickname, Pageable pageable);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/member/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.review.ReviewRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.trip_schedule.TripSchedule;
 import kr.ac.kumoh.illdang100.tovalley.domain.trip_schedule.TripScheduleRepository;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
 import kr.ac.kumoh.illdang100.tovalley.dto.member.MemberReqDto.SignUpReqDto;
 import kr.ac.kumoh.illdang100.tovalley.handler.ex.CustomApiException;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtVO;
@@ -16,6 +17,8 @@ import kr.ac.kumoh.illdang100.tovalley.service.S3Service;
 import kr.ac.kumoh.illdang100.tovalley.util.TokenUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -217,5 +220,10 @@ public class MemberServiceImpl implements MemberService {
 
     private boolean hasAccountProfileImage(Member member) {
         return member.getImageFile() != null;
+    }
+
+    @Override
+    public Slice<SearchMembersRespDto> searchMembers(String nickname, Pageable pageable) {
+        return memberRepository.findSliceMembersByNickname(nickname, pageable);
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/controller/admin/AdminController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/controller/admin/AdminController.java
@@ -1,11 +1,17 @@
 package kr.ac.kumoh.illdang100.tovalley.web.controller.admin;
 
 import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleReqDto;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleReqDto.SearchMembersCondition;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
 import kr.ac.kumoh.illdang100.tovalley.form.admin.LoginForm;
 import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtVO;
 import kr.ac.kumoh.illdang100.tovalley.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +38,7 @@ public class AdminController {
 
     /**
      * 관리자 로그아웃
+     *
      * @return 관리자용 로그인 페이지
      */
     @GetMapping("/logout")
@@ -44,6 +51,7 @@ public class AdminController {
 
     /**
      * 사용자 권한 변경 페이지
+     *
      * @param model
      * @return
      */
@@ -54,24 +62,34 @@ public class AdminController {
 
     /**
      * 사용자 권한 변경
+     *
      * @param adminChangeRoleReqDto
      * @param refreshTokenId
      * @param nmodel
      * @return
      */
     @PostMapping("/change-role")
-    public String changeRole(AdminChangeRoleReqDto adminChangeRoleReqDto, @CookieValue(JwtVO.REFRESH_TOKEN) String refreshTokenId, Model nmodel) {
+    public String changeRole(AdminChangeRoleReqDto adminChangeRoleReqDto,
+                             @CookieValue(JwtVO.REFRESH_TOKEN) String refreshTokenId, Model nmodel) {
         return "admin/change-role";
     }
 
     /**
      * 사용자 검색 - 닉네임
-     * @param nickname
+     *
+     * @param searchMembersCondition
      * @param model
      * @return
      */
     @PostMapping("/members")
-    public String getMemberList(String nickname, Model model) {
+    public String getMemberList(@ModelAttribute SearchMembersCondition searchMembersCondition,
+                                @PageableDefault(size = 10, sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable,
+                                Model model) {
+
+        Slice<SearchMembersRespDto> searchUsersRespDtos
+                = memberService.searchMembers(searchMembersCondition.getNickname(), pageable);
+        model.addAttribute("searchUsersRespDtos", searchUsersRespDtos);
+
         return "admin/change-role";
     }
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImplTest.java
@@ -1,0 +1,112 @@
+package kr.ac.kumoh.illdang100.tovalley.domain.member;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import kr.ac.kumoh.illdang100.tovalley.dto.admin.AdminChangeRoleRespDto.SearchMembersRespDto;
+import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class MemberRepositoryImplTest extends DummyObject {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    public void setUp() {
+        autoIncrementReset();
+        dataSetting();
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("닉네임 입력 없이 조회 테스트")
+    public void findSliceMembersByNickname_test() {
+
+        // given
+        PageRequest pageable =
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "nickname"));
+
+        // when
+        List<SearchMembersRespDto> content = memberRepository.findSliceMembersByNickname(null, pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(10);
+        assertThat(content.get(0).getNickname()).isEqualTo("member1");
+        assertThat(content.get(0).getRole()).isEqualTo("CUSTOMER");
+        assertThat(content.get(1).getNickname()).isEqualTo("member10");
+    }
+
+    @Test
+    @DisplayName("닉네임 입력하고 조회 테스트")
+    public void findSliceMembersByNickname_test2() {
+
+        // given
+        String nickname = "member20";
+        PageRequest pageable =
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "nickname"));
+
+        // when
+        List<SearchMembersRespDto> content = memberRepository.findSliceMembersByNickname(nickname, pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(1);
+        assertThat(content.get(0).getNickname()).isEqualTo("member20");
+        assertThat(content.get(0).getRole()).isEqualTo("CUSTOMER");
+    }
+
+    private void autoIncrementReset() {
+
+        em.createNativeQuery("ALTER TABLE member ALTER COLUMN member_id RESTART WITH 1").executeUpdate();
+    }
+
+    private void dataSetting() {
+        memberRepository.save(newMember("kakao_1234", "member1"));
+        memberRepository.save(newMember("kakao_5678", "member2"));
+        memberRepository.save(newMember("kakao_9101", "member3"));
+        memberRepository.save(newMember("kakao_1121", "member4"));
+        memberRepository.save(newMember("kakao_3141", "member5"));
+        memberRepository.save(newMember("kakao_4231", "member6"));
+
+        memberRepository.save(newMember("kakao_12334", "member7"));
+        memberRepository.save(newMember("kakao_56678", "member8"));
+        memberRepository.save(newMember("kakao_91701", "member9"));
+        memberRepository.save(newMember("kakao_11291", "member10"));
+        memberRepository.save(newMember("kakao_31141", "member11"));
+        memberRepository.save(newMember("kakao_42341", "member12"));
+
+        memberRepository.save(newMember("kakao_11234", "member13"));
+        memberRepository.save(newMember("kakao_56798", "member14"));
+        memberRepository.save(newMember("kakao_91071", "member15"));
+        memberRepository.save(newMember("kakao_11261", "member16"));
+        memberRepository.save(newMember("kakao_31441", "member17"));
+        memberRepository.save(newMember("kakao_43231", "member18"));
+
+        memberRepository.save(newMember("kakao_12634", "member19"));
+        memberRepository.save(newMember("kakao_56788", "member20"));
+        memberRepository.save(newMember("kakao_91011", "member21"));
+        memberRepository.save(newMember("kakao_11121", "member22"));
+        memberRepository.save(newMember("kakao_31541", "member23"));
+        memberRepository.save(newMember("kakao_42431", "member24"));
+
+        memberRepository.save(newMember("kakao_12374", "member25"));
+        memberRepository.save(newMember("kakao_56778", "member26"));
+        memberRepository.save(newMember("kakao_91017", "member27"));
+        memberRepository.save(newMember("kakao_11217", "member28"));
+        memberRepository.save(newMember("kakao_31417", "member29"));
+        memberRepository.save(newMember("kakao_42317", "member30"));
+    }
+}

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/domain/member/MemberRepositoryImplTest.java
@@ -68,6 +68,22 @@ class MemberRepositoryImplTest extends DummyObject {
         assertThat(content.get(0).getRole()).isEqualTo("CUSTOMER");
     }
 
+    @Test
+    @DisplayName("존재하지 않는 닉네임 입력하고 조회 테스트")
+    public void findSliceMembersByNickname_test3() {
+
+        // given
+        String nickname = "member888";
+        PageRequest pageable =
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "nickname"));
+
+        // when
+        List<SearchMembersRespDto> content = memberRepository.findSliceMembersByNickname(nickname, pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(0);
+    }
+
     private void autoIncrementReset() {
 
         em.createNativeQuery("ALTER TABLE member ALTER COLUMN member_id RESTART WITH 1").executeUpdate();


### PR DESCRIPTION
CH-15 관리자용 사용자 검색 기능 구현
- 사용자 검색을 위한 SearchMembersCondition 클래스 생성
  - 사용자 닉네임 필드 존재 (null이어도 됨)
- 사용자 검색 결과 반환을 위한 SearchMembersRespDto 클래스 생성
  - 사용자 pk, 이메일, 이름, 닉네임, 역할
- QueryDSL을 사용한 사용자 검색 결과 반환
  - MemberRepositoryCustom, MemberRepositoryCustomImpl
- 테스트 케이스 작성
  - 사용자 닉네임 없이 테스트 하는 경우(결과, 개수, 정렬 검사)
  - 사용자 닉네임 입력하여 테스트 하는 경우
  - 존재하지 않는 사용자 닉네임 입력하는 경우