### PR TITLE
CH-24 분실물 상세 조회 페이지 기능 구현

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/comment/CommentRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/comment/CommentRepository.java
@@ -2,5 +2,11 @@ package kr.ac.kumoh.illdang100.tovalley.domain.comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findCommentByLostFoundBoardId(long lostFoundBoardId);
+
+    long countByLostFoundBoardId(long lostFoundBoardId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardImage.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardImage.java
@@ -6,10 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 
 @Entity
@@ -21,6 +18,7 @@ public class LostFoundBoardImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long lostFoundBoardId;
 
     private ImageFile imageFile;

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardImageRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardImageRepository.java
@@ -1,6 +1,11 @@
 package kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface LostFoundBoardImageRepository extends JpaRepository<LostFoundBoardImage, Long> {
+    @Query("SELECT li.imageFile.storeFileUrl FROM LostFoundBoardImage li where li.lostFoundBoardId = :lostFoundBoardId")
+    List<String> findImageByLostFoundBoardId(long lostFoundBoardId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/water_place/WaterPlaceRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/water_place/WaterPlaceRepository.java
@@ -17,7 +17,4 @@ public interface WaterPlaceRepository extends JpaRepository<WaterPlace, Long>, W
     List<WaterPlace> findTop8ByOrderByReviewCountDesc(Pageable pageable);
 
     List<WaterPlace> findByWaterPlaceNameIn(List<String> valleyNames);
-
-    @Query("select wp.waterPlaceName from WaterPlace wp")
-    List<String> findWaterPlaceNames();
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/water_place/WaterPlaceRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/water_place/WaterPlaceRepository.java
@@ -17,4 +17,7 @@ public interface WaterPlaceRepository extends JpaRepository<WaterPlace, Long>, W
     List<WaterPlace> findTop8ByOrderByReviewCountDesc(Pageable pageable);
 
     List<WaterPlace> findByWaterPlaceNameIn(List<String> valleyNames);
+
+    @Query("select wp.waterPlaceName from WaterPlace wp")
+    List<String> findWaterPlaceNames();
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
@@ -3,10 +3,11 @@ package kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundEnum;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class LostFoundBoardRespDto {
 
@@ -22,5 +23,29 @@ public class LostFoundBoardRespDto {
         private LocalDateTime postCreateAt;
         private String postImage;
         private LostFoundEnum category;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class LostFoundBoardDetailRespDto {
+        private String title;
+        private String content;
+        private String author;
+        @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+        private LocalDateTime postCreateAt;
+        private List<String> postImages;
+        private Long commentCnt;
+        private List<CommentDetailRespDto> comments;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class CommentDetailRespDto {
+        private String commentAuthor;
+        private String commentContent;
+        @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+        private LocalDateTime commentCreateAt;
+        private boolean isMyComment;
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
@@ -5,6 +5,7 @@ import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +28,7 @@ public class LostFoundBoardRespDto {
 
     @Data
     @Builder
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class LostFoundBoardDetailRespDto {
         private String title;

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/water_place/WaterPlaceRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/water_place/WaterPlaceRespDto.java
@@ -154,4 +154,12 @@ public class WaterPlaceRespDto {
         private Double rating; // 평점
         private String waterPlaceCategory; // 구분
     }
+
+    @Data
+    @AllArgsConstructor
+    public static class LostFoundBoardWaterPlaceDto {
+        private Long waterPlaceId;
+        private String waterPlaceName;
+        private String address;
+    }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
@@ -1,19 +1,6 @@
 package kr.ac.kumoh.illdang100.tovalley.service.lost_found_board;
 
-
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
-
 public interface LostFoundBoardService {
-    // 분실물 게시글 조회 메서드
-    Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardListReqDto lostFoundBoardListReqDto, Pageable pageable);
-
-    // 분실물 게시글 상세 페이지 조회 메서드
-    LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, long memberId);
-
     // 분실물 게시글 등록
 
     // 분실물 게시글 수정

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
@@ -12,6 +12,7 @@ public interface LostFoundBoardService {
     Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardListReqDto lostFoundBoardListReqDto, Pageable pageable);
 
     // 분실물 게시글 상세 페이지 조회 메서드
+    LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, long memberId);
 
     // 분실물 게시글 등록
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
@@ -1,6 +1,11 @@
 package kr.ac.kumoh.illdang100.tovalley.service.lost_found_board;
 
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardImageRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -8,8 +13,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.util.EntityFinder.*;
 
 @Slf4j
 @Service
@@ -18,10 +27,52 @@ import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoar
 public class LostFoundBoardServiceImpl implements LostFoundBoardService{
 
     private final LostFoundBoardRepository lostFoundBoardRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final LostFoundBoardImageRepository lostFoundBoardImageRepository;
 
-
+    /**
+     * 분실물 찾기 게시글 조회
+     * @param LostFoundBoardListReqDto
+     * @param pageable
+     * @return
+     */
     @Override
     public Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardListReqDto LostFoundBoardListReqDto, Pageable pageable) {
         return lostFoundBoardRepository.getLostFoundBoardListBySlice(LostFoundBoardListReqDto, pageable);
+    }
+
+    /**
+     * 분실물 찾기 게시글 상세 페이지
+     * @param lostFoundBoardId
+     * @param memberId
+     * @return
+     */
+    @Override
+    public LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, long memberId) {
+
+        LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdOrElseThrow(lostFoundBoardRepository, lostFoundBoardId);
+
+        return LostFoundBoardDetailRespDto.builder()
+                .title(findLostFoundBoard.getTitle())
+                .content(findLostFoundBoard.getContent())
+                .author(findLostFoundBoard.getMember().getNickname())
+                .postCreateAt(findLostFoundBoard.getCreatedDate())
+                .comments(findCommentDetails(lostFoundBoardId, memberId))
+                .postImages(lostFoundBoardImageRepository.findImageByLostFoundBoardId(lostFoundBoardId))
+                .commentCnt(commentRepository.countByLostFoundBoardId(lostFoundBoardId))
+                .build();
+    }
+
+    private List<CommentDetailRespDto> findCommentDetails(long lostFoundBoardId, long memberId) {
+        return commentRepository.findCommentByLostFoundBoardId(lostFoundBoardId)
+                .stream()
+                .map(c -> new CommentDetailRespDto(c.getAuthorEmail(), c.getContent(), c.getCreatedDate(), isMyComment(memberId, c.getAuthorEmail())))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMyComment(long memberId, String authorEmail) {
+        Member findMember = findMemberByEmailOrElseThrowEx(memberRepository, authorEmail);
+        return (memberId == findMember.getId());
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
@@ -1,24 +1,13 @@
 package kr.ac.kumoh.illdang100.tovalley.service.lost_found_board;
 
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardImageRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
-import static kr.ac.kumoh.illdang100.tovalley.util.EntityFinder.*;
 
 @Slf4j
 @Service
@@ -30,49 +19,4 @@ public class LostFoundBoardServiceImpl implements LostFoundBoardService{
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final LostFoundBoardImageRepository lostFoundBoardImageRepository;
-
-    /**
-     * 분실물 찾기 게시글 조회
-     * @param LostFoundBoardListReqDto
-     * @param pageable
-     * @return
-     */
-    @Override
-    public Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardListReqDto LostFoundBoardListReqDto, Pageable pageable) {
-        return lostFoundBoardRepository.getLostFoundBoardListBySlice(LostFoundBoardListReqDto, pageable);
-    }
-
-    /**
-     * 분실물 찾기 게시글 상세 페이지
-     * @param lostFoundBoardId
-     * @param memberId
-     * @return
-     */
-    @Override
-    public LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, long memberId) {
-
-        LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdOrElseThrow(lostFoundBoardRepository, lostFoundBoardId);
-
-        return LostFoundBoardDetailRespDto.builder()
-                .title(findLostFoundBoard.getTitle())
-                .content(findLostFoundBoard.getContent())
-                .author(findLostFoundBoard.getMember().getNickname())
-                .postCreateAt(findLostFoundBoard.getCreatedDate())
-                .comments(findCommentDetails(lostFoundBoardId, memberId))
-                .postImages(lostFoundBoardImageRepository.findImageByLostFoundBoardId(lostFoundBoardId))
-                .commentCnt(commentRepository.countByLostFoundBoardId(lostFoundBoardId))
-                .build();
-    }
-
-    private List<CommentDetailRespDto> findCommentDetails(long lostFoundBoardId, long memberId) {
-        return commentRepository.findCommentByLostFoundBoardId(lostFoundBoardId)
-                .stream()
-                .map(c -> new CommentDetailRespDto(c.getAuthorEmail(), c.getContent(), c.getCreatedDate(), isMyComment(memberId, c.getAuthorEmail())))
-                .collect(Collectors.toList());
-    }
-
-    private boolean isMyComment(long memberId, String authorEmail) {
-        Member findMember = findMemberByEmailOrElseThrowEx(memberRepository, authorEmail);
-        return (memberId == findMember.getId());
-    }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageService.java
@@ -1,7 +1,10 @@
 package kr.ac.kumoh.illdang100.tovalley.service.page;
 
+import kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
+import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.page.PageRespDto.*;
 
 public interface PageService {
@@ -11,4 +14,8 @@ public interface PageService {
     WaterPlaceDetailPageAllRespDto getWaterPlaceDetailPageAllData(Long waterPlaceId, Pageable pageable);
 
     MyPageAllRespDto getMyPageAllData(Long memberId, Pageable pageable);
+
+    Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardReqDto.LostFoundBoardListReqDto lostFoundBoardListReqDto, Pageable pageable);
+
+    LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String memberEmail);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageService.java
@@ -17,5 +17,5 @@ public interface PageService {
 
     Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardReqDto.LostFoundBoardListReqDto lostFoundBoardListReqDto, Pageable pageable);
 
-    LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String memberEmail);
+    LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String refreshToken);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
@@ -5,7 +5,8 @@ import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardImageRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
+import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
+import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
 import kr.ac.kumoh.illdang100.tovalley.service.accident.AccidentService;
 import kr.ac.kumoh.illdang100.tovalley.service.member.MemberService;
 import kr.ac.kumoh.illdang100.tovalley.service.review.ReviewService;
@@ -50,8 +51,8 @@ public class PageServiceImpl implements PageService{
     private final MemberService memberService;
     private final LostFoundBoardRepository lostFoundBoardRepository;
     private final CommentRepository commentRepository;
-    private final MemberRepository memberRepository;
     private final LostFoundBoardImageRepository lostFoundBoardImageRepository;
+    private final JwtProcess jwtProcess;
 
     /**
      * @methodnme: getMainPageAllData
@@ -154,20 +155,22 @@ public class PageServiceImpl implements PageService{
     /**
      * 분실물 찾기 게시글 상세 페이지 조회
      * @param lostFoundBoardId
-     * @param memberEmail
+     * @param refreshToken
      * @return
      */
     @Override
-    public LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String memberEmail) {
+    public LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String refreshToken) {
 
         LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdOrElseThrow(lostFoundBoardRepository, lostFoundBoardId);
+
+        PrincipalDetails principalDetails = jwtProcess.verify(refreshToken);
 
         return LostFoundBoardDetailRespDto.builder()
                 .title(findLostFoundBoard.getTitle())
                 .content(findLostFoundBoard.getContent())
                 .author(findLostFoundBoard.getMember().getNickname())
                 .postCreateAt(findLostFoundBoard.getCreatedDate())
-                .comments(findCommentDetails(lostFoundBoardId, memberEmail))
+                .comments(findCommentDetails(lostFoundBoardId, principalDetails.getMember().getEmail()))
                 .postImages(lostFoundBoardImageRepository.findImageByLostFoundBoardId(lostFoundBoardId))
                 .commentCnt(commentRepository.countByLostFoundBoardId(lostFoundBoardId))
                 .build();

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
@@ -1,8 +1,11 @@
 package kr.ac.kumoh.illdang100.tovalley.service.page;
 
 import kr.ac.kumoh.illdang100.tovalley.domain.ProvinceEnum;
-import kr.ac.kumoh.illdang100.tovalley.dto.member.MemberRespDto;
-import kr.ac.kumoh.illdang100.tovalley.dto.trip_schedule.TripScheduleRespDto;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardImageRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import kr.ac.kumoh.illdang100.tovalley.service.accident.AccidentService;
 import kr.ac.kumoh.illdang100.tovalley.service.member.MemberService;
 import kr.ac.kumoh.illdang100.tovalley.service.review.ReviewService;
@@ -20,8 +23,11 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static kr.ac.kumoh.illdang100.tovalley.dto.accident.AccidentRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.member.MemberRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.page.PageRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.rescue_supply.RescueSupplyRespDto.*;
@@ -29,6 +35,7 @@ import static kr.ac.kumoh.illdang100.tovalley.dto.review.ReviewRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.trip_schedule.TripScheduleRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.water_place.WaterPlaceRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.weather.WeatherRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.util.EntityFinder.findLostFoundBoardByIdOrElseThrow;
 
 @Slf4j
 @Service
@@ -41,6 +48,10 @@ public class PageServiceImpl implements PageService{
     private final ReviewService reviewService;
     private final TripScheduleService tripScheduleService;
     private final MemberService memberService;
+    private final LostFoundBoardRepository lostFoundBoardRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final LostFoundBoardImageRepository lostFoundBoardImageRepository;
 
     /**
      * @methodnme: getMainPageAllData
@@ -127,5 +138,49 @@ public class PageServiceImpl implements PageService{
         List<MyTripScheduleRespDto> upcomingTripSchedules = tripScheduleService.getUpcomingTripSchedules(memberId);
 
         return new MyPageAllRespDto(memberDetail, reviewsByMemberId, upcomingTripSchedules);
+    }
+
+    /**
+     * 분실물 찾기 게시글 조회
+     * @param LostFoundBoardListReqDto
+     * @param pageable
+     * @return
+     */
+    @Override
+    public Slice<LostFoundBoardListRespDto> getLostFoundBoardList(LostFoundBoardListReqDto LostFoundBoardListReqDto, Pageable pageable) {
+        return lostFoundBoardRepository.getLostFoundBoardListBySlice(LostFoundBoardListReqDto, pageable);
+    }
+
+    /**
+     * 분실물 찾기 게시글 상세 페이지 조회
+     * @param lostFoundBoardId
+     * @param memberEmail
+     * @return
+     */
+    @Override
+    public LostFoundBoardDetailRespDto getLostFoundBoardDetail(long lostFoundBoardId, String memberEmail) {
+
+        LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdOrElseThrow(lostFoundBoardRepository, lostFoundBoardId);
+
+        return LostFoundBoardDetailRespDto.builder()
+                .title(findLostFoundBoard.getTitle())
+                .content(findLostFoundBoard.getContent())
+                .author(findLostFoundBoard.getMember().getNickname())
+                .postCreateAt(findLostFoundBoard.getCreatedDate())
+                .comments(findCommentDetails(lostFoundBoardId, memberEmail))
+                .postImages(lostFoundBoardImageRepository.findImageByLostFoundBoardId(lostFoundBoardId))
+                .commentCnt(commentRepository.countByLostFoundBoardId(lostFoundBoardId))
+                .build();
+    }
+
+    private List<CommentDetailRespDto> findCommentDetails(long lostFoundBoardId, String memberEmail) {
+        return commentRepository.findCommentByLostFoundBoardId(lostFoundBoardId)
+                .stream()
+                .map(c -> new CommentDetailRespDto(c.getAuthorEmail(), c.getContent(), c.getCreatedDate(), isMyComment(memberEmail, c.getAuthorEmail())))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMyComment(String memberEmail, String authorEmail) {
+        return (memberEmail.equals(authorEmail));
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceService.java
@@ -34,5 +34,5 @@ public interface WaterPlaceService {
 
     Page<AdminRetrieveWaterPlacesDto> getAdminWaterPlaceList(String searchWord, Pageable pageable);
 
-    List<String> getWaterPlaceNames();
+    List<LostFoundBoardWaterPlaceDto> getWaterPlaceNames();
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceService.java
@@ -33,4 +33,6 @@ public interface WaterPlaceService {
     void saveNewWaterPlace(CreateWaterPlaceForm form);
 
     Page<AdminRetrieveWaterPlacesDto> getAdminWaterPlaceList(String searchWord, Pageable pageable);
+
+    List<String> getWaterPlaceNames();
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceServiceImpl.java
@@ -241,6 +241,15 @@ public class WaterPlaceServiceImpl implements WaterPlaceService {
         return waterPlaceRepository.getAdminWaterPlaceList(searchWord, pageable);
     }
 
+    /**
+     * @description 분실문 찾기 게시판에서 계곡 선택 시 사용
+     * @return
+     */
+    @Override
+    public List<String> getWaterPlaceNames() {
+        return waterPlaceRepository.findWaterPlaceNames();
+    }
+
     private void processImageUpdate(WaterPlace waterPlace, MultipartFile waterPlaceImage) {
         try {
             if (waterPlaceImage != null) {

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/water_place/WaterPlaceServiceImpl.java
@@ -246,8 +246,10 @@ public class WaterPlaceServiceImpl implements WaterPlaceService {
      * @return
      */
     @Override
-    public List<String> getWaterPlaceNames() {
-        return waterPlaceRepository.findWaterPlaceNames();
+    public List<LostFoundBoardWaterPlaceDto> getWaterPlaceNames() {
+        return waterPlaceRepository.findAll().stream()
+                .map(waterPlace -> new LostFoundBoardWaterPlaceDto(waterPlace.getId(), waterPlace.getWaterPlaceName(), waterPlace.getAddress()))
+                .collect(Collectors.toList());
     }
 
     private void processImageUpdate(WaterPlace waterPlace, MultipartFile waterPlaceImage) {

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
@@ -4,6 +4,8 @@ import kr.ac.kumoh.illdang100.tovalley.domain.accident.Accident;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.email_code.EmailCode;
 import kr.ac.kumoh.illdang100.tovalley.domain.email_code.EmailCodeRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.trip_schedule.TripSchedule;
@@ -66,5 +68,9 @@ public class EntityFinder {
 
         return accidentRepository.findByIdAndWaterPlaceId(accidentId, waterPlaceId)
                 .orElseThrow(() -> new CustomApiException("물놀이 장소[" + waterPlaceId + "]에 대한 사고[" + accidentId + "]가 존재하지 않습니다"));
+    }
+
+    public static LostFoundBoard findLostFoundBoardByIdOrElseThrow(LostFoundBoardRepository lostFoundBoardRepository, long lostFoundBoardId) {
+        return lostFoundBoardRepository.findById(lostFoundBoardId).orElseThrow(() -> new CustomApiException("분실물 찾기 게시글[" + lostFoundBoardId + "]이 존재하지 않습니다"));
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.illdang100.tovalley.web.api;
 
 import kr.ac.kumoh.illdang100.tovalley.dto.ResponseDto;
+import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
 import kr.ac.kumoh.illdang100.tovalley.service.lost_found_board.LostFoundBoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,11 +11,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -36,5 +35,14 @@ public class LostFoundBoardController {
         Slice<LostFoundBoardListRespDto> lostFoundBoardList = lostFoundBoardService.getLostFoundBoardList(lostFoundBoardListReqDto, pageable);
 
         return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 페이지 조회를 성공했습니다", lostFoundBoardList), HttpStatus.OK);
+    }
+
+    @GetMapping("/lostItem/{lostFoundBoardId}")
+    public ResponseEntity<?> getLostFoundBoardDetail(@PathVariable long lostFoundBoardId,
+                                                     @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        LostFoundBoardDetailRespDto lostFoundBoardDetail = lostFoundBoardService.getLostFoundBoardDetail(lostFoundBoardId, principalDetails.getMember().getId());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 상세 페이지 조회를 성공했습니다", lostFoundBoardDetail), HttpStatus.OK);
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
@@ -1,24 +1,9 @@
 package kr.ac.kumoh.illdang100.tovalley.web.api;
 
-import kr.ac.kumoh.illdang100.tovalley.dto.ResponseDto;
-import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
 import kr.ac.kumoh.illdang100.tovalley.service.lost_found_board.LostFoundBoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
 
 @Slf4j
 @RestController
@@ -26,23 +11,4 @@ import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoar
 @RequestMapping("/api")
 public class LostFoundBoardController {
     private final LostFoundBoardService lostFoundBoardService;
-
-    @GetMapping("/lostItem")
-    public ResponseEntity<?> getLostFoundBoardList(@ModelAttribute @Valid LostFoundBoardListReqDto lostFoundBoardListReqDto,
-                                                   BindingResult bindingResult,
-                                                   @PageableDefault(size = 5, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-
-        Slice<LostFoundBoardListRespDto> lostFoundBoardList = lostFoundBoardService.getLostFoundBoardList(lostFoundBoardListReqDto, pageable);
-
-        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 페이지 조회를 성공했습니다", lostFoundBoardList), HttpStatus.OK);
-    }
-
-    @GetMapping("/lostItem/{lostFoundBoardId}")
-    public ResponseEntity<?> getLostFoundBoardDetail(@PathVariable long lostFoundBoardId,
-                                                     @AuthenticationPrincipal PrincipalDetails principalDetails) {
-
-        LostFoundBoardDetailRespDto lostFoundBoardDetail = lostFoundBoardService.getLostFoundBoardDetail(lostFoundBoardId, principalDetails.getMember().getId());
-
-        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 상세 페이지 조회를 성공했습니다", lostFoundBoardDetail), HttpStatus.OK);
-    }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
@@ -79,12 +79,7 @@ public class PageApiController {
     public ResponseEntity<?> getLostFoundBoardDetail(@PathVariable long lostFoundBoardId,
                                                      @CookieValue(JwtVO.REFRESH_TOKEN) String refreshToken) {
 
-        PrincipalDetails principalDetails = jwtProcess.verify(refreshToken);
-
-        LostFoundBoardDetailRespDto lostFoundBoardDetail = new LostFoundBoardDetailRespDto();
-        if (principalDetails != null) {
-            lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, principalDetails.getMember().getEmail());
-        }
+        LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, refreshToken);
 
         return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 상세 페이지 조회를 성공했습니다", lostFoundBoardDetail), HttpStatus.OK);
     }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
@@ -3,17 +3,23 @@ package kr.ac.kumoh.illdang100.tovalley.web.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.kumoh.illdang100.tovalley.dto.ResponseDto;
+import kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto;
+import kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto;
 import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
 import kr.ac.kumoh.illdang100.tovalley.service.page.PageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 import static kr.ac.kumoh.illdang100.tovalley.dto.page.PageRespDto.*;
 
@@ -54,5 +60,24 @@ public class PageApiController {
         MyPageAllRespDto result = pageService.getMyPageAllData(memberId, pageable);
 
         return new ResponseEntity<>(new ResponseDto<>(1, "마이 페이지 조회에 성공하였습니다", result), HttpStatus.OK);
+    }
+
+    @GetMapping("/lostItem")
+    public ResponseEntity<?> getLostFoundBoardList(@ModelAttribute @Valid LostFoundBoardReqDto.LostFoundBoardListReqDto lostFoundBoardListReqDto,
+                                                   BindingResult bindingResult,
+                                                   @PageableDefault(size = 5, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Slice<LostFoundBoardRespDto.LostFoundBoardListRespDto> lostFoundBoardList = pageService.getLostFoundBoardList(lostFoundBoardListReqDto, pageable);
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 페이지 조회를 성공했습니다", lostFoundBoardList), HttpStatus.OK);
+    }
+
+    @GetMapping("/auth/lostItem/{lostFoundBoardId}")
+    public ResponseEntity<?> getLostFoundBoardDetail(@PathVariable long lostFoundBoardId,
+                                                     @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        LostFoundBoardRespDto.LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, principalDetails.getMember().getEmail());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 찾기 상세 페이지 조회를 성공했습니다", lostFoundBoardDetail), HttpStatus.OK);
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/WaterPlaceApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/WaterPlaceApiController.java
@@ -9,9 +9,6 @@ import kr.ac.kumoh.illdang100.tovalley.service.water_place.WaterPlaceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -52,5 +49,11 @@ public class WaterPlaceApiController {
         Page<RetrieveWaterPlacesDto> result = waterPlaceService.getWaterPlaces(retrieveWaterPlacesCondition);
 
         return new ResponseEntity<>(new ResponseDto<>(1, "전국 물놀이 지역 조회에 성공하였습니다.", result), HttpStatus.OK);
+    }
+
+    @GetMapping("/water-place")
+    public ResponseEntity<?> getWaterPlaceNames() {
+        List<String> waterPlaceNames = waterPlaceService.getWaterPlaceNames();
+        return new ResponseEntity<>(new ResponseDto<>(1, "물놀이 장소 이름 리스트 조회에 성공하였습니다", waterPlaceNames), HttpStatus.OK);
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/WaterPlaceApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/WaterPlaceApiController.java
@@ -53,7 +53,7 @@ public class WaterPlaceApiController {
 
     @GetMapping("/water-place")
     public ResponseEntity<?> getWaterPlaceNames() {
-        List<String> waterPlaceNames = waterPlaceService.getWaterPlaceNames();
+        List<LostFoundBoardWaterPlaceDto> waterPlaceNames = waterPlaceService.getWaterPlaceNames();
         return new ResponseEntity<>(new ResponseDto<>(1, "물놀이 장소 이름 리스트 조회에 성공하였습니다", waterPlaceNames), HttpStatus.OK);
     }
 }

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImplTest.java
@@ -1,0 +1,82 @@
+package kr.ac.kumoh.illdang100.tovalley.service.lost_found_board;
+
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardImageRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundEnum;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberEnum;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlace;
+import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class LostFoundBoardServiceImplTest extends DummyObject {
+    @InjectMocks
+    private LostFoundBoardServiceImpl lostFoundBoardService;
+    @Mock
+    private LostFoundBoardRepository lostFoundBoardRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private LostFoundBoardImageRepository lostFoundBoardImageRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    public void getLostFoundBoardDetails() {
+        // given
+        long lostFoundBoardId = 1L;
+        long memberId = 1L;
+        Member member = newMockMember(1L, "kakao_1234", "nickname1", MemberEnum.CUSTOMER);
+        Member comment_member = newMockMember(2L, "user", "nickname2", MemberEnum.CUSTOMER);
+        WaterPlace waterPlace = newWaterPlace(1L, "금오계곡", "경북", 3.5, 3);
+        LostFoundBoard lostFoundBoard = newLostFoundBoard(1L, "지갑 찾아요", "금오계곡에서 지갑 잃어버림 검정색 지갑", member, false, LostFoundEnum.LOST, waterPlace);
+
+        List<Comment> comments = new ArrayList<>();
+        comments.add(newComment(1L, 1L));
+        comments.add(newComment(2L, 1L));
+        comments.add(newComment(3L, 1L));
+
+        List<String> postImages = new ArrayList<>();
+        postImages.add("https://imageUrl1.com");
+        postImages.add("https://imageUrl2.com");
+        postImages.add("https://imageUrl3.com");
+
+        // stub
+        when(lostFoundBoardRepository.findById(anyLong())).thenReturn(Optional.of(lostFoundBoard));
+        when(memberRepository.findByEmail(any())).thenReturn(Optional.of(comment_member));
+        when(commentRepository.findCommentByLostFoundBoardId(anyLong())).thenReturn(comments);
+        when(lostFoundBoardImageRepository.findImageByLostFoundBoardId(anyLong())).thenReturn(postImages);
+        when(commentRepository.countByLostFoundBoardId(anyLong())).thenReturn((long)comments.size());
+
+        // when
+        LostFoundBoardDetailRespDto lostFoundBoardDetail = lostFoundBoardService.getLostFoundBoardDetail(lostFoundBoardId, memberId);
+
+        // then
+        assertThat(lostFoundBoardDetail.getTitle()).isEqualTo("지갑 찾아요");
+        assertThat(lostFoundBoardDetail.getContent()).isEqualTo("금오계곡에서 지갑 잃어버림 검정색 지갑");
+        assertThat(lostFoundBoardDetail.getCommentCnt()).isEqualTo(3);
+        assertThat(lostFoundBoardDetail.getPostImages().size()).isEqualTo(3);
+    }
+
+}

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.illdang100.tovalley.service.lost_found_board;
+package kr.ac.kumoh.illdang100.tovalley.service.page;
 
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class LostFoundBoardServiceImplTest extends DummyObject {
     @InjectMocks
-    private LostFoundBoardServiceImpl lostFoundBoardService;
+    private PageServiceImpl pageService;
     @Mock
     private LostFoundBoardRepository lostFoundBoardRepository;
     @Mock
@@ -46,9 +46,8 @@ class LostFoundBoardServiceImplTest extends DummyObject {
     public void getLostFoundBoardDetails() {
         // given
         long lostFoundBoardId = 1L;
-        long memberId = 1L;
+        String memberEmail = "kakao_1234@naver.com";
         Member member = newMockMember(1L, "kakao_1234", "nickname1", MemberEnum.CUSTOMER);
-        Member comment_member = newMockMember(2L, "user", "nickname2", MemberEnum.CUSTOMER);
         WaterPlace waterPlace = newWaterPlace(1L, "금오계곡", "경북", 3.5, 3);
         LostFoundBoard lostFoundBoard = newLostFoundBoard(1L, "지갑 찾아요", "금오계곡에서 지갑 잃어버림 검정색 지갑", member, false, LostFoundEnum.LOST, waterPlace);
 
@@ -64,13 +63,12 @@ class LostFoundBoardServiceImplTest extends DummyObject {
 
         // stub
         when(lostFoundBoardRepository.findById(anyLong())).thenReturn(Optional.of(lostFoundBoard));
-        when(memberRepository.findByEmail(any())).thenReturn(Optional.of(comment_member));
         when(commentRepository.findCommentByLostFoundBoardId(anyLong())).thenReturn(comments);
         when(lostFoundBoardImageRepository.findImageByLostFoundBoardId(anyLong())).thenReturn(postImages);
         when(commentRepository.countByLostFoundBoardId(anyLong())).thenReturn((long)comments.size());
 
         // when
-        LostFoundBoardDetailRespDto lostFoundBoardDetail = lostFoundBoardService.getLostFoundBoardDetail(lostFoundBoardId, memberId);
+        LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, memberEmail);
 
         // then
         assertThat(lostFoundBoardDetail.getTitle()).isEqualTo("지갑 찾아요");

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
@@ -8,9 +8,10 @@ import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRep
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundEnum;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberEnum;
-import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlace;
 import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
+import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
+import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,7 +41,7 @@ class LostFoundBoardServiceImplTest extends DummyObject {
     @Mock
     private LostFoundBoardImageRepository lostFoundBoardImageRepository;
     @Mock
-    private MemberRepository memberRepository;
+    private JwtProcess jwtProcess;
 
     @Test
     public void getLostFoundBoardDetails() {
@@ -66,9 +67,10 @@ class LostFoundBoardServiceImplTest extends DummyObject {
         when(commentRepository.findCommentByLostFoundBoardId(anyLong())).thenReturn(comments);
         when(lostFoundBoardImageRepository.findImageByLostFoundBoardId(anyLong())).thenReturn(postImages);
         when(commentRepository.countByLostFoundBoardId(anyLong())).thenReturn((long)comments.size());
+        when(jwtProcess.verify(any())).thenReturn(new PrincipalDetails(member));
 
         // when
-        LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, memberEmail);
+        LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, "refreshToken");
 
         // then
         assertThat(lostFoundBoardDetail.getTitle()).isEqualTo("지갑 찾아요");

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/AccidentApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/AccidentApiControllerTest.java
@@ -6,7 +6,6 @@ import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentEnum;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlace;
 import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlaceRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.weather.national_weather.NationalRegion;
 import kr.ac.kumoh.illdang100.tovalley.domain.weather.national_weather.NationalRegionRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.weather.national_weather.NationalWeatherRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.weather.special_weather.*;
@@ -26,7 +25,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import javax.persistence.EntityManager;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/WaterPlaceApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/WaterPlaceApiControllerTest.java
@@ -96,8 +96,8 @@ public class WaterPlaceApiControllerTest extends DummyObject {
         // then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0]").value("서울계곡"))
-                .andExpect(jsonPath("$.data[4]").value("세종계곡"));
+                .andExpect(jsonPath("$.data[0].waterPlaceName").value("서울계곡"))
+                .andExpect(jsonPath("$.data[4].waterPlaceName").value("세종계곡"));
     }
 
     private void dataSetting() {

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/WaterPlaceApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/WaterPlaceApiControllerTest.java
@@ -12,8 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.TestExecutionEvent;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
@@ -85,6 +83,21 @@ public class WaterPlaceApiControllerTest extends DummyObject {
                 .andExpect(jsonPath("$.data[0].waterPlaceName").value("서울계곡"))
                 .andExpect(jsonPath("$.data[4].waterPlaceName").value("세종계곡"))
                 .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    public void getWaterPlaceNames() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/water-place")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0]").value("서울계곡"))
+                .andExpect(jsonPath("$.data[4]").value("세종계곡"));
     }
 
     private void dataSetting() {

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/LostFoundBoardControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/LostFoundBoardControllerTest.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.illdang100.tovalley.web.api;
+package kr.ac.kumoh.illdang100.tovalley.web.page;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MainPageApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MainPageApiControllerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MyPageApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MyPageApiControllerTest.java
@@ -1,8 +1,6 @@
 package kr.ac.kumoh.illdang100.tovalley.web.page;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.ac.kumoh.illdang100.tovalley.domain.accident.Accident;
-import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentEnum;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
@@ -10,10 +8,6 @@ import kr.ac.kumoh.illdang100.tovalley.domain.review.*;
 import kr.ac.kumoh.illdang100.tovalley.domain.trip_schedule.TripSchedule;
 import kr.ac.kumoh.illdang100.tovalley.domain.trip_schedule.TripScheduleRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.water_place.*;
-import kr.ac.kumoh.illdang100.tovalley.domain.weather.national_weather.NationalRegionRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.weather.national_weather.NationalWeatherRepository;
-import kr.ac.kumoh.illdang100.tovalley.domain.weather.special_weather.*;
-import kr.ac.kumoh.illdang100.tovalley.domain.weather.water_place_weather.WaterPlaceWeather;
 import kr.ac.kumoh.illdang100.tovalley.domain.weather.water_place_weather.WaterPlaceWeatherRepository;
 import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
- 분실물 상세 조회 페이지 기능 구현
- 분실물 상세 페이지 기능 서비스 코드 작성
- 물놀이 장소 이름 조회 기능 구현
- CookieValue 어노테이션 사용해서 refreshToken 받아오고 JwtProcess의 verify 메서드 사용해 principalDeatils 객체 받아오도록 구현함
- refreshToken 통해 Member 객체의 email 추출하는 로직 위치 변경 (컨트롤러 -> 서비스)