### PR TITLE
CH-34 분실물 게시글 삭제

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardImageService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardImageService.java
@@ -12,4 +12,6 @@ public interface LostFoundBoardImageService {
     void deleteLostFoundImageFiles(List<String> imageFileUrls, Long lostFoundBoardId, Long memberId);
 
     void validateImageCount(LostFoundBoardReqDto.LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto, LostFoundBoard findLostFoundBoard);
+
+    List<String> deleteLostFoundBoardImageInBatch(Long lostFoundBoardId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardService.java
@@ -5,13 +5,9 @@ import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
 
 public interface LostFoundBoardService {
-    // 분실물 게시글 등록
     Long saveLostFoundBoard(LostFoundBoardSaveReqDto lostFoundBoardSaveReqDto, Long memberId);
 
-    // 분실물 게시글 수정
     LostFoundBoard updateLostFoundBoard(LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto, Long memberId);
 
-    // 분실물 게시글 삭제
-
-    Boolean isAuthorizedToAccessBoard(LostFoundBoard lostFoundBoard, Long memberId);
+    void deleteLostFoundBoard(Long lostFoundBoardId, Long memberId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/AuthorizationUtil.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/AuthorizationUtil.java
@@ -1,0 +1,15 @@
+package kr.ac.kumoh.illdang100.tovalley.util;
+
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+
+public class AuthorizationUtil {
+    public static Boolean isAuthorizedToAccessBoard(LostFoundBoard lostFoundBoard, Long memberId) {
+        boolean result = false;
+        Member member = lostFoundBoard.getMember();
+        if (member != null) {
+            result = lostFoundBoard.getMember().getId().equals(memberId);
+        }
+        return result;
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
@@ -67,4 +67,16 @@ public class LostFoundBoardController {
 
         return new ResponseEntity<>(new ResponseDto<>(1, "분실물 게시글이 정상적으로 수정되었습니다", null), HttpStatus.OK);
     }
+
+    @DeleteMapping(value = "/auth/lostItem/{lostFoundBoardId}")
+    public ResponseEntity<?> deleteLostFoundBoard(@PathVariable("lostFoundBoardId") long lostFoundBoardId,
+                                                  @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        List<String> deleteLostFoundBoardImageFileName = lostFoundBoardImageService.deleteLostFoundBoardImageInBatch(lostFoundBoardId);
+        s3Service.deleteFiles(deleteLostFoundBoardImageFileName);
+
+        lostFoundBoardService.deleteLostFoundBoard(lostFoundBoardId, principalDetails.getMember().getId());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "분실물 게시글이 정상적으로 삭제되었습니다", null), HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
- 분실물 게시글 삭제 기능 구현 (서비스, 컨트롤러, 테스트)
  - db에 저장된 이미지, s3에 저장된 이미지, 댓글 삭제 후 게시글 삭제