### PR TITLE
feat: 댓글 작성 및 삭제 기능 구현 

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/comment/CommentRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/comment/CommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -14,4 +15,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select c from Comment c JOIN FETCH c.member m where c.lostFoundBoardId = :lostFoundBoardId")
     List<Comment> findCommentByLostFoundBoardIdFetchJoinMember(@Param("lostFoundBoardId")Long lostFoundBoardId);
+    
+    @Query("select c from Comment c JOIN FETCH c.member m where c.id = :commentId")
+    Optional<Comment> findCommentByIdFetchJoinMember(@Param("commentId")Long commentId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepository.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepository.java
@@ -9,5 +9,8 @@ import java.util.Optional;
 public interface LostFoundBoardRepository extends JpaRepository<LostFoundBoard, Long>, LostFoundBoardRepositoryCustom {
 
     @Query("select lfb from LostFoundBoard lfb JOIN FETCH lfb.member m JOIN FETCH lfb.waterPlace wp where lfb.id = :lostFoundBoardId")
-    Optional<LostFoundBoard> findByIdWithMemberAndWaterPlace(@Param("lostFoundBoardId")long lostFoundBoardId);
+    Optional<LostFoundBoard> findByIdWithMemberAndWaterPlace(@Param("lostFoundBoardId")Long lostFoundBoardId);
+
+    @Query("select lfb from LostFoundBoard lfb JOIN FETCH lfb.member m where lfb.id = :lostFoundBoardId")
+    Optional<LostFoundBoard> findByIdWithMember(@Param("lostFoundBoardId")Long lostFoundBoardId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/comment/CommentReqDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/comment/CommentReqDto.java
@@ -1,0 +1,20 @@
+package kr.ac.kumoh.illdang100.tovalley.dto.comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class CommentReqDto {
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentSaveReqDto {
+        @NotBlank
+        @Size(max = 256, message = "내용은 256자 이하로 작성해주세요")
+        private String commentContent;
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/comment/CommentRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/comment/CommentRespDto.java
@@ -1,0 +1,46 @@
+package kr.ac.kumoh.illdang100.tovalley.dto.comment;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public class CommentRespDto {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class CommentSaveRespDto {
+        private Long commentId;
+        private String commentAuthor;
+        private String commentContent;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime commentCreateAt;
+        private String commentAuthorProfile;
+
+        public static CommentSaveRespDto createCommentSaveRespDto(Comment comment, Member member) {
+            return CommentSaveRespDto.builder()
+                    .commentId(comment.getId())
+                    .commentAuthor(member.getNickname())
+                    .commentContent(comment.getContent())
+                    .commentCreateAt(comment.getCreatedDate())
+                    .commentAuthorProfile(member.getImageFile().getStoreFileUrl())
+                    .build();
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class CommentDetailRespDto {
+        private Long commentId;
+        private String commentAuthor;
+        private String commentContent;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime commentCreateAt;
+        private boolean commentByUser;
+        private String commentAuthorProfile;
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
+
 public class LostFoundBoardRespDto {
 
     @Data
@@ -63,17 +65,5 @@ public class LostFoundBoardRespDto {
                     .commentCnt(commentCnt)
                     .build();
         }
-    }
-
-    @Data
-    @AllArgsConstructor
-    public static class CommentDetailRespDto {
-        private Long commentId;
-        private String commentAuthor;
-        private String commentContent;
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private LocalDateTime commentCreateAt;
-        private boolean commentByUser;
-        private String commentAuthorProfile;
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/comment/CommentService.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/comment/CommentService.java
@@ -1,5 +1,13 @@
 package kr.ac.kumoh.illdang100.tovalley.service.comment;
 
+import kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentReqDto.CommentSaveReqDto;
+
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
+
 public interface CommentService {
     void deleteCommentByLostFoundBoardIdInBatch(Long lostFoundBoardId);
+
+    CommentSaveRespDto saveComment(Long lostFoundBoardId, CommentSaveReqDto commentSaveReqDto, Long memberId);
+
+    void deleteComment(Long lostFoundBoardId, Long commentId, Long memberId);
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/comment/CommentServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/comment/CommentServiceImpl.java
@@ -2,6 +2,12 @@ package kr.ac.kumoh.illdang100.tovalley.service.comment;
 
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
+import kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentReqDto.CommentSaveReqDto;
+import kr.ac.kumoh.illdang100.tovalley.handler.ex.CustomApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -9,6 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.CommentSaveRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.util.EntityFinder.*;
 
 import static kr.ac.kumoh.illdang100.tovalley.util.ListUtil.isEmptyList;
 
@@ -19,6 +29,8 @@ import static kr.ac.kumoh.illdang100.tovalley.util.ListUtil.isEmptyList;
 public class CommentServiceImpl implements CommentService {
 
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final LostFoundBoardRepository lostFoundBoardRepository;
 
     @Override
     public void deleteCommentByLostFoundBoardIdInBatch(Long lostFoundBoardId) {
@@ -29,5 +41,36 @@ public class CommentServiceImpl implements CommentService {
                     .map(Comment::getId)
                     .collect(Collectors.toList()));
         }
+    }
+
+    @Override
+    @Transactional
+    public CommentSaveRespDto saveComment(Long lostFoundBoardId, CommentSaveReqDto commentSaveReqDto, Long memberId) {
+        Member findMember = findMemberByIdOrElseThrowEx(memberRepository, memberId);
+        LostFoundBoard findLostFoundBoard = findLostFoundBoardOrElseThrowEx(lostFoundBoardRepository, lostFoundBoardId);
+
+        Comment savedComment = commentRepository.save(Comment.builder()
+                .content(commentSaveReqDto.getCommentContent())
+                .member(findMember)
+                .lostFoundBoardId(findLostFoundBoard.getId())
+                .build());
+
+        return createCommentSaveRespDto(savedComment, findMember);
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(Long lostFoundBoardId, Long commentId, Long memberId) {
+        Member findMember = findMemberByIdOrElseThrowEx(memberRepository, memberId);
+        Comment findComment = findCommentByIdWithMemberOrElseThrowEx(commentRepository, commentId);
+
+        if (!isMyComment(findComment, findMember.getId())) {
+            throw new CustomApiException("댓글 작성자에게만 권한이 있습니다");
+        }
+        commentRepository.delete(findComment);
+    }
+
+    private Boolean isMyComment(Comment comment, Long memberId) {
+        return comment.getMember().getId().equals(memberId);
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImpl.java
@@ -56,7 +56,7 @@ public class LostFoundBoardServiceImpl implements LostFoundBoardService {
     @Override
     @Transactional
     public LostFoundBoard updateLostFoundBoard(LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto, Long memberId) {
-        LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdWithMemberOrElseThrowEx(lostFoundBoardRepository, lostFoundBoardUpdateReqDto.getLostFoundBoardId());
+        LostFoundBoard findLostFoundBoard = findLostFoundBoardByIdWithMemberAndWaterPlaceOrElseThrowEx(lostFoundBoardRepository, lostFoundBoardUpdateReqDto.getLostFoundBoardId());
         checkBoardAccessPermission(findLostFoundBoard, memberId);
 
         WaterPlace findWaterPlace = findWaterPlaceByIdOrElseThrowEx(waterPlaceRepository, lostFoundBoardUpdateReqDto.getWaterPlaceId());

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static kr.ac.kumoh.illdang100.tovalley.dto.accident.AccidentRespDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.LostFoundBoardDetailRespDto.*;
@@ -181,7 +182,7 @@ public class PageServiceImpl implements PageService{
                     Member member = c.getMember();
                     boolean isMyComment = memberEmail != null && isMyCommentByMemberEmail(memberEmail, member);
                     String storeFileUrl = member.getImageFile() != null ? member.getImageFile().getStoreFileUrl() : null;
-                    return new CommentDetailRespDto(c.getId(), member.getEmail(), c.getContent(), c.getCreatedDate(), isMyComment, storeFileUrl);
+                    return new CommentDetailRespDto(c.getId(), member.getNickname(), c.getContent(), c.getCreatedDate(), isMyComment, storeFileUrl);
                 })
                 .collect(Collectors.toList());
     }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/util/EntityFinder.java
@@ -3,6 +3,8 @@ package kr.ac.kumoh.illdang100.tovalley.util;
 import java.util.NoSuchElementException;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.Accident;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.email_code.EmailCode;
 import kr.ac.kumoh.illdang100.tovalley.domain.email_code.EmailCodeRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoard;
@@ -71,11 +73,19 @@ public class EntityFinder {
                 .orElseThrow(() -> new CustomApiException("물놀이 장소[" + waterPlaceId + "]에 대한 사고[" + accidentId + "]가 존재하지 않습니다"));
     }
 
-    public static LostFoundBoard findLostFoundBoardByIdWithMemberOrElseThrowEx(LostFoundBoardRepository lostFoundBoardRepository, Long lostFoundBoardId) {
+    public static LostFoundBoard findLostFoundBoardByIdWithMemberAndWaterPlaceOrElseThrowEx(LostFoundBoardRepository lostFoundBoardRepository, Long lostFoundBoardId) {
         return lostFoundBoardRepository.findByIdWithMemberAndWaterPlace(lostFoundBoardId).orElseThrow(() -> new CustomApiException("분실물 찾기 게시글[" + lostFoundBoardId + "]이 존재하지 않습니다"));
+    }
+
+    public static LostFoundBoard findLostFoundBoardByIdWithMemberOrElseThrowEx(LostFoundBoardRepository lostFoundBoardRepository, Long lostFoundBoardId) {
+        return lostFoundBoardRepository.findByIdWithMember(lostFoundBoardId).orElseThrow(() -> new CustomApiException("분실물 찾기 게시글[" + lostFoundBoardId + "]이 존재하지 않습니다"));
     }
 
     public static LostFoundBoard findLostFoundBoardOrElseThrowEx(LostFoundBoardRepository lostFoundBoardRepository, Long lostFoundBoardId) {
         return lostFoundBoardRepository.findById(lostFoundBoardId).orElseThrow(() -> new CustomApiException("분실물 찾기 게시글[" + lostFoundBoardId + "]이 존재하지 않습니다"));
+    }
+
+    public static Comment findCommentByIdWithMemberOrElseThrowEx(CommentRepository commentRepository, Long commentId) {
+        return commentRepository.findCommentByIdFetchJoinMember(commentId).orElseThrow(() -> new CustomApiException("댓글[" + commentId + "]이 존재하지 않습니다"));
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/CommentController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/CommentController.java
@@ -1,0 +1,46 @@
+package kr.ac.kumoh.illdang100.tovalley.web.api;
+
+import kr.ac.kumoh.illdang100.tovalley.dto.ResponseDto;
+import kr.ac.kumoh.illdang100.tovalley.security.auth.PrincipalDetails;
+import kr.ac.kumoh.illdang100.tovalley.service.comment.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentReqDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping(value = "/auth/lostItem/{lostFoundBoardId}/comment")
+    public ResponseEntity<?> saveComment(@PathVariable("lostFoundBoardId")Long lostFoundBoardId,
+                                         @RequestBody @Valid CommentSaveReqDto commentSaveReqDto,
+                                         BindingResult bindingResult,
+                                         @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        CommentSaveRespDto commentSaveRespDto = commentService.saveComment(lostFoundBoardId, commentSaveReqDto, principalDetails.getMember().getId());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "댓글이 정상적으로 등록되었습니다", commentSaveRespDto), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping(value = "/auth/lostItem/{lostFoundBoardId}/comment/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable("lostFoundBoardId")Long lostFoundBoardId,
+                                           @PathVariable("commentId")Long commentId,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        commentService.deleteComment(lostFoundBoardId, commentId, principalDetails.getMember().getId());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "댓글이 정상적으로 삭제되었습니다", null), HttpStatus.OK);
+    }
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
@@ -32,7 +32,7 @@ public class LostFoundBoardController {
     private final S3Service s3Service;
 
     @PostMapping(value = "/auth/lostItem")
-    public ResponseEntity<?> saveLostFoundBoard(@RequestBody @Valid LostFoundBoardSaveReqDto lostFoundBoardSaveReqDto,
+    public ResponseEntity<?> saveLostFoundBoard(@ModelAttribute @Valid LostFoundBoardSaveReqDto lostFoundBoardSaveReqDto,
                                                 BindingResult bindingResult,
                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
 
@@ -45,7 +45,7 @@ public class LostFoundBoardController {
     }
 
     @PatchMapping(value = "/auth/lostItem")
-    public ResponseEntity<?> updateLostFoundBoard(@RequestBody @Valid LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto,
+    public ResponseEntity<?> updateLostFoundBoard(@ModelAttribute @Valid LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto,
                                                   BindingResult bindingResult,
                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/lost_found_board/LostFoundBoardServiceImplTest.java
@@ -77,7 +77,7 @@ class LostFoundBoardServiceImplTest extends DummyObject {
         lostFoundBoardService.updateLostFoundBoard(lostFoundBoardUpdateReqDto, memberId);
 
         // stub2
-        when(lostFoundBoardRepository.findByIdWithMemberAndWaterPlace(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
+        when(lostFoundBoardRepository.findByIdWithMember(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
 
         LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, member);
 
@@ -196,7 +196,7 @@ class LostFoundBoardServiceImplTest extends DummyObject {
         lostFoundBoardService.updateLostFoundBoard(lostFoundBoardUpdateReqDto, memberId);
 
         // stub2
-        when(lostFoundBoardRepository.findByIdWithMemberAndWaterPlace(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
+        when(lostFoundBoardRepository.findByIdWithMember(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
 
         LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, member);
 
@@ -223,7 +223,7 @@ class LostFoundBoardServiceImplTest extends DummyObject {
         lostFoundBoardService.updateResolvedStatus(lostFoundBoardId, true, memberId);
 
         // stub2
-        when(lostFoundBoardRepository.findByIdWithMemberAndWaterPlace(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
+        when(lostFoundBoardRepository.findByIdWithMember(lostFoundBoardId)).thenReturn(Optional.of(lostFoundBoard));
 
         LostFoundBoardDetailRespDto lostFoundBoardDetail = pageService.getLostFoundBoardDetail(lostFoundBoardId, member);
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/service/page/LostFoundBoardServiceImplTest.java
@@ -58,7 +58,7 @@ class LostFoundBoardServiceImplTest extends DummyObject {
         postImages.add("https://imageUrl3.com");
 
         // stub
-        when(lostFoundBoardRepository.findByIdWithMemberAndWaterPlace(anyLong())).thenReturn(Optional.of(lostFoundBoard));
+        when(lostFoundBoardRepository.findByIdWithMember(anyLong())).thenReturn(Optional.of(lostFoundBoard));
         when(commentRepository.findCommentByLostFoundBoardIdFetchJoinMember(anyLong())).thenReturn(comments);
         when(lostFoundBoardImageRepository.findImageByLostFoundBoardId(anyLong())).thenReturn(postImages);
         when(commentRepository.countByLostFoundBoardId(anyLong())).thenReturn((long)comments.size());

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/CommentControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/CommentControllerTest.java
@@ -1,0 +1,112 @@
+package kr.ac.kumoh.illdang100.tovalley.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundBoardRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.lost_found_board.LostFoundEnum;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
+import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlace;
+import kr.ac.kumoh.illdang100.tovalley.domain.water_place.WaterPlaceRepository;
+import kr.ac.kumoh.illdang100.tovalley.dummy.DummyObject;
+import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtProcess;
+import kr.ac.kumoh.illdang100.tovalley.security.jwt.JwtVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import javax.persistence.EntityManager;
+import javax.servlet.http.Cookie;
+
+import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentReqDto.*;
+import static kr.ac.kumoh.illdang100.tovalley.util.TokenUtil.createTestAccessToken;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Sql("classpath:db/teardown.sql")
+class CommentControllerTest extends DummyObject {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private LostFoundBoardRepository lostFoundBoardRepository;
+
+    @Autowired
+    private WaterPlaceRepository waterPlaceRepository;
+
+    @Autowired
+    private JwtProcess jwtProcess;
+
+    private String accessToken;
+
+    @BeforeEach
+    public void setUp() {
+        dataSetting();
+        accessToken = createTestAccessToken(memberRepository, jwtProcess, "kakao_123");
+    }
+
+    @Test
+    @DisplayName(value = "분실물 댓글 등록 실패 - 빈 문자열")
+    void saveLostFoundBoardEmptyString() throws Exception {
+        // given
+        Long lostFoundBoardId = 3L;
+        CommentSaveReqDto commentSaveReqDto = new CommentSaveReqDto("");
+        String requestBody = om.writeValueAsString(commentSaveReqDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/auth/lostItem/" + lostFoundBoardId + "/comment")
+                .content(requestBody)
+                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    private void dataSetting() {
+        Member member = newMember("kakao_123", "일당백");
+        memberRepository.save(member);
+
+        WaterPlace waterPlace1 = newWaterPlace(1L, "금오계곡", "경상북도", 3.0, 3);
+        waterPlaceRepository.save(waterPlace1);
+        WaterPlace waterPlace2 = newWaterPlace(2L, "대구계곡", "경상북도", 3.0, 3);
+        waterPlaceRepository.save(waterPlace2);
+
+        lostFoundBoardRepository.save(newMockLostFoundBoard(1L, "지갑 보신 분", "지갑", member, false, LostFoundEnum.LOST, waterPlace1));
+        lostFoundBoardRepository.save(newMockLostFoundBoard(2L, "지갑 찾습니다.", "지갑", member, false, LostFoundEnum.LOST, waterPlace1));
+        lostFoundBoardRepository.save(newMockLostFoundBoard(3L, "폰 찾았어요", "아이폰14", member, false, LostFoundEnum.FOUND, waterPlace2));
+        lostFoundBoardRepository.save(newMockLostFoundBoard(4L, "폰 잃어버리신 분", "갤럭시S20", member, true, LostFoundEnum.FOUND, waterPlace2));
+
+        commentRepository.save(newMockComment(1L, 1L, member));
+        commentRepository.save(newMockComment(2L, 1L, member));
+
+        em.clear();
+    }
+
+}

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/LostFoundBoardControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/LostFoundBoardControllerTest.java
@@ -18,20 +18,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import javax.persistence.EntityManager;
 import javax.servlet.http.Cookie;
 
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.*;
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.LostFoundBoardSaveReqDto;
 import static kr.ac.kumoh.illdang100.tovalley.util.TokenUtil.createTestAccessToken;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -79,39 +78,25 @@ class LostFoundBoardControllerTest extends DummyObject {
         Long waterPlaceId = 1L;
         LostFoundBoardSaveReqDto lostFoundBoardSaveReqDto = new LostFoundBoardSaveReqDto("LOST", waterPlaceId, "잃어버림", "지갑 잃어버렸어요", null);
 
-        String requestBody = om.writeValueAsString(lostFoundBoardSaveReqDto);
+        MockMultipartFile file1 = new MockMultipartFile("postImage", "image1.jpg", "image/jpeg", "some image".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("postImage", "image2.jpg", "image/jpeg", "some image".getBytes());
 
         // when
-        ResultActions resultActions = mvc.perform(post("/api/auth/lostItem")
-                .content(requestBody)
-                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
-                .contentType(MediaType.APPLICATION_JSON));
+        ResultActions resultActions = mvc.perform(
+                MockMvcRequestBuilders.multipart("/api/auth/lostItem")
+                        .file(file1)
+                        .file(file2)
+                        .param("category", lostFoundBoardSaveReqDto.getCategory())
+                        .param("waterPlaceId", lostFoundBoardSaveReqDto.getWaterPlaceId().toString())
+                        .param("title", lostFoundBoardSaveReqDto.getTitle())
+                        .param("content", lostFoundBoardSaveReqDto.getContent())
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+        );
 
         // then
         resultActions
                 .andExpect(status().isCreated())
-                .andDo(MockMvcResultHandlers.print());
-    }
-
-    @Test
-    @DisplayName(value = "분실물 게시글 수정")
-    void updateLostFoundBoard() throws Exception {
-        // given
-        Long waterPlaceId = 2L;
-        Long lostFoundBoardId = 2L;
-        LostFoundBoardUpdateReqDto lostFoundBoardUpdateReqDto = new LostFoundBoardUpdateReqDto(lostFoundBoardId, "LOST", waterPlaceId, "지갑 잃어버렸습니다ㅠㅠ", "지갑 좀 찾아주세요 검정색 카드지갑 입니다!!", null, null);
-
-        String requestBody = om.writeValueAsString(lostFoundBoardUpdateReqDto);
-
-        // when
-        ResultActions resultActions = mvc.perform(patch("/api/auth/lostItem")
-                .content(requestBody)
-                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
-                .contentType(MediaType.APPLICATION_JSON));
-
-        // then
-        resultActions
-                .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
     }
 


### PR DESCRIPTION
### 기능 구현
- 댓글 작성 및 삭제 구현

### 수정 사항
- CommentDetailRespDto 위치 변경 (CommentRespDto 클래스)
- 게시글 등록, 수정: 컨트롤러에서 DTO 받아올 때 @ModelAttribute 사용
- 게시글 작성 테스트 코드 수정
- 게시글 상세 페이지 조회 시 댓글에 사용자 닉네임 전달하도록 수정
- LostFoundBoardRepository findByIdWithMember(Member만 fetch join), findByIdWithMemberAndWaterPlace 메서드 분리(Member, WaterPlace와 fetch join) -> Member만 필요한 곳에선 findByIdWithMember 호출하도록 수정