### PR TITLE
채팅방 구독 해제 오류 해결 & 채팅 이미지 전송 기능 구현

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/config/chat/StompHandler.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/config/chat/StompHandler.java
@@ -119,11 +119,13 @@ public class StompHandler implements ChannelInterceptor { // WebSocket을 이용
     }
 
     private void handleUnsubscribe(StompHeaderAccessor accessor) {
-        if (accessor.getDestination().startsWith(TOPIC_NOTIFICATION)) {
+        String destination = accessor.getDestination();
+        if (destination != null && accessor.getDestination().startsWith(TOPIC_NOTIFICATION)) {
             log.debug("알림 UNSUBSCRIBE");
             return;
         }
 
+        // 채팅방 구독 해지 처리
         handleChatRoomUnsubscription(accessor);
     }
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/FileRootPathVO.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/FileRootPathVO.java
@@ -6,4 +6,5 @@ public interface FileRootPathVO {
     public static final String REVIEW_PATH = "review";
     public static final String WATER_PLACE_PATH = "waterPlace";
     public static final String LOST_FOUND_BOARD_PATH = "lostFoundBoard";
+    public static final String CHAT_PATH = "chat";
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/ChatMessage.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/ChatMessage.java
@@ -23,5 +23,9 @@ public class ChatMessage {
     // 예를 들어, 사용자가 다른 시간대에서 메시지를 보냈다면, ZonedDateTime을 사용해 메시지를 보낸 시간을 해당 시간대의 시간으로 정확하게 표시할 수 있다.
     private String createdAt;
     private int readCount;
-    //    private String contentType;
+
+    private ChatType chatType; // 채팅 타입 필드 추가('TEXT', 'IMAGE')
+
+    private String imageName;
+    private String imageUrl;
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/ChatType.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/ChatType.java
@@ -1,0 +1,12 @@
+package kr.ac.kumoh.illdang100.tovalley.domain.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ChatType {
+    TEXT("텍스트"), IMAGE("이미지");
+
+    private final String value;
+}

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/kafka/Message.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/chat/kafka/Message.java
@@ -2,6 +2,7 @@ package kr.ac.kumoh.illdang100.tovalley.domain.chat.kafka;
 
 import java.io.Serializable;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatMessage;
+import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +21,6 @@ import lombok.ToString;
 @AllArgsConstructor
 public class Message implements Serializable {
 
-//    private String id;
-
     private Long chatRoomId;
 
     private Long senderId;
@@ -31,7 +30,10 @@ public class Message implements Serializable {
     private String createdAt;
     private int readCount;
 
-//    private String contentType;
+    private ChatType chatType; // 채팅 타입 필드 추가('TEXT', 'IMAGE')
+
+    private String imageName; // 이미지 파일 이름
+    private String imageUrl; // 이미지 URL
 
     public void prepareMessageForSending(Long senderId, String createdAt, int readCount) {
         this.senderId = senderId;
@@ -41,12 +43,14 @@ public class Message implements Serializable {
 
     public ChatMessage convertToChatMessage() {
         return ChatMessage.builder()
-//                .id(id)
                 .chatRoomId(chatRoomId)
                 .senderId(senderId)
                 .content(content)
                 .createdAt(createdAt)
                 .readCount(readCount)
+                .chatType(chatType)
+                .imageName(imageName)
+                .imageUrl(imageUrl)
                 .build();
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/chat/ChatRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/chat/ChatRespDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatMessage;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatRoom;
+import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatType;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.util.ChatUtil;
 import lombok.AllArgsConstructor;
@@ -82,6 +83,8 @@ public class ChatRespDto {
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
         private int readCount;
+        private ChatType chatType; // 채팅 타입 필드('TEXT', 'IMAGE')
+        private String imageUrl; // 이미지 URL
 
         public ChatMessageRespDto(ChatMessage chatMessage, Long memberId) {
             this.chatMessageId = chatMessage.getId();
@@ -90,6 +93,8 @@ public class ChatRespDto {
             this.content = chatMessage.getContent();
             this.createdAt = ChatUtil.convertZdtStringToLocalDateTime(chatMessage.getCreatedAt());
             this.readCount = chatMessage.getReadCount();
+            this.chatType = chatMessage.getChatType();
+            this.imageUrl = chatMessage.getImageUrl();
         }
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dummy/DummyObject.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dummy/DummyObject.java
@@ -7,6 +7,7 @@ import kr.ac.kumoh.illdang100.tovalley.domain.ImageFile;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.Accident;
 import kr.ac.kumoh.illdang100.tovalley.domain.accident.AccidentEnum;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatMessage;
+import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatType;
 import kr.ac.kumoh.illdang100.tovalley.domain.notification.ChatNotification;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatRoom;
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.Comment;
@@ -434,13 +435,17 @@ public class DummyObject {
                 .build();
     }
 
-    protected ChatMessage newChatMessage(Long chatRoomId, Long senderId, String content) {
+    protected ChatMessage newChatMessage(Long chatRoomId, Long senderId, String content,
+                                         ChatType chatType, String imageName, String imageUrl) {
         return ChatMessage.builder()
                 .chatRoomId(chatRoomId)
                 .senderId(senderId)
                 .content(content)
                 .createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toString())
                 .readCount(1)
+                .chatType(chatType)
+                .imageName(imageName)
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/chat/ChatServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/chat/ChatServiceImpl.java
@@ -154,23 +154,23 @@ public class ChatServiceImpl implements ChatService {
         return chatRooms;
     }
 
-    private void processSingleChatRoom(ChatRoomRespDto chatRoom, Long memberId) {
-        long unreadMessageCount = countUnReadMessages(chatRoom.getChatRoomId(), memberId);
-        chatRoom.changeUnReadMessageCount(unreadMessageCount);
-        updateChatRoomWithLastMessageIfExists(chatRoom);
+    private void processSingleChatRoom(ChatRoomRespDto chatRoomRespDto, Long memberId) {
+        long unreadMessageCount = countUnReadMessages(chatRoomRespDto.getChatRoomId(), memberId);
+        chatRoomRespDto.changeUnReadMessageCount(unreadMessageCount);
+        updateChatRoomWithLastMessageIfExists(chatRoomRespDto);
     }
 
-    private void updateChatRoomWithLastMessageIfExists(ChatRoomRespDto chatRoom) {
-        Optional<ChatMessage> lastMessageOpt = findLastMessageInChatRoom(chatRoom.getChatRoomId());
-        lastMessageOpt.ifPresent((lastMessage) -> updateChatRoomWithLastMessage(chatRoom, lastMessage));
+    private void updateChatRoomWithLastMessageIfExists(ChatRoomRespDto chatRoomRespDto) {
+        Optional<ChatMessage> lastMessageOpt = findLastMessageInChatRoom(chatRoomRespDto.getChatRoomId());
+        lastMessageOpt.ifPresent((lastMessage) -> updateChatRoomWithLastMessage(chatRoomRespDto, lastMessage));
     }
 
     private Optional<ChatMessage> findLastMessageInChatRoom(Long chatRoomId) {
         return chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(chatRoomId);
     }
 
-    private void updateChatRoomWithLastMessage(ChatRoomRespDto chatRoom, ChatMessage lastMessage) {
-        chatRoom.changeLastMessage(lastMessage.getContent(),
+    private void updateChatRoomWithLastMessage(ChatRoomRespDto chatRoomRespDto, ChatMessage lastMessage) {
+        chatRoomRespDto.changeLastMessage(lastMessage.getContent(),
                 ChatUtil.convertZdtStringToLocalDateTime(lastMessage.getCreatedAt()));
     }
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/ChatApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/ChatApiController.java
@@ -94,7 +94,7 @@ public class ChatApiController {
     }
 
     @PostMapping(value = "/api/auth/chat/images/upload")
-    public ResponseEntity<?> changeProfileImage(@RequestPart(value = "image", required = false) MultipartFile chatImage) {
+    public ResponseEntity<?> saveChatImage(@RequestPart(value = "image", required = false) MultipartFile chatImage) {
 
         // chatImage가 null인 경우 처리
         if (chatImage == null || chatImage.isEmpty()) {

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/api/ChatApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/api/ChatApiControllerTest.java
@@ -13,6 +13,7 @@ import javax.servlet.http.Cookie;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatMessageRepository;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatRoom;
 import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatRoomRepository;
+import kr.ac.kumoh.illdang100.tovalley.domain.chat.ChatType;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.Member;
 import kr.ac.kumoh.illdang100.tovalley.domain.member.MemberRepository;
 import kr.ac.kumoh.illdang100.tovalley.dto.chat.ChatReqDto.CreateNewChatRoomReqDto;
@@ -172,16 +173,30 @@ class ChatApiControllerTest extends DummyObject {
 
         // 첫 페이지의 마지막 채팅 메시지 ID를 cursor로 사용
         String responseJson = firstPageResult.getResponse().getContentAsString();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(responseJson);
+        JsonNode rootNode = om.readTree(responseJson);
         String lastChatMessageId = rootNode.path("data").path("chatMessages").path("content").get(0).path("chatMessageId").asText();
         System.out.println("lastChatMessageId = " + lastChatMessageId);
 
         // 두 번째 페이지 조회
-        mvc.perform(get("/api/auth/chat/messages/1")
+        MvcResult secondPageResult = mvc.perform(get("/api/auth/chat/messages/1")
                         .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("cursor", lastChatMessageId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("채팅 메시지 목록 조회에 성공했습니다"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        String responseJson2 = secondPageResult.getResponse().getContentAsString();
+        JsonNode rootNode2 = om.readTree(responseJson2);
+        String lastChatMessageId2 = rootNode2.path("data").path("chatMessages").path("content").get(0).path("chatMessageId").asText();
+        System.out.println("lastChatMessageId2 = " + lastChatMessageId2);
+
+        // 세 번째 페이지 조회
+        mvc.perform(get("/api/auth/chat/messages/1")
+                        .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("cursor", lastChatMessageId2))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("채팅 메시지 목록 조회에 성공했습니다"))
                 .andDo(MockMvcResultHandlers.print());
@@ -220,38 +235,18 @@ class ChatApiControllerTest extends DummyObject {
         ChatRoom chatRoom2 = chatRoomRepository.save(newChatRoom(sender, recipient2));
         ChatRoom chatRoom3 = chatRoomRepository.save(newChatRoom(sender2, recipient2));
         ChatRoom chatRoom4 = chatRoomRepository.save(newChatRoom(sender, recipient3));
-//        chatMessageRepository.save(newChatMessage(chatRoom3.getId(), recipient2.getId(), "content1"));
+//        chatMessageRepository.save(newChatMessage(chatRoom3.getId(), recipient2.getId(), "content1", ChatType.TEXT, null, null));
 
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content31"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content32"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content33"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content34"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content35"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content36"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content37"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content38"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content39"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content40"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content41"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content42"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content43"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content44"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content45"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content46"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content47"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content48"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content49"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content50"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content51"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content52"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content53"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content54"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content55"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content26"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content27"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content28"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content29"));
-//        chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content30"));
+//        int tmp = 1;
+//        for (int i = 0; i < 10; i++) {
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content" + tmp++, ChatType.TEXT, null, null));
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content" + tmp++, ChatType.TEXT, null, null));
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content" + tmp++, ChatType.TEXT, null, null));
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), sender.getId(), "content" + tmp++, ChatType.TEXT, null, null));
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "content" + tmp++, ChatType.TEXT, null, null));
+//            chatMessageRepository.save(newChatMessage(chatRoom.getId(), recipient.getId(), "사진을 보냈습니다.", ChatType.IMAGE, "imageName.jpg", "https://imageUrl.com"));
+//            tmp++;
+//        }
         em.clear();
     }
 }

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MyPageApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/MyPageApiControllerTest.java
@@ -91,7 +91,7 @@ public class MyPageApiControllerTest extends DummyObject {
                 .andExpect(jsonPath("$.data.myUpcomingTripSchedules[0].tripScheduleId").value(13))
                 .andExpect(jsonPath("$.data.myUpcomingTripSchedules[1].tripScheduleId").value(14))
                 .andExpect(jsonPath("$.data.myUpcomingTripSchedules[2].tripScheduleId").value(15))
-                .andExpect(jsonPath("$.data.myLostFoundBoards.content[0].title").value("title1"))
+                .andExpect(jsonPath("$.data.myLostFoundBoards.content[0].title").value("title10"))
                 .andExpect(jsonPath("$.data.myLostFoundBoards.content[4].title").value("title6"))
                 .andDo(MockMvcResultHandlers.print());
     }


### PR DESCRIPTION
- 채팅방 구독 해제 즉, STOMP의 UNSUBSCRIBE 요청이 들어올 때, StompHeaderAccessor accessor 객체의 getDestination() 메서드 값에 null 예외처리하여 문제 해결
- 채팅 이미지 전송 기능 구현