### PR TITLE
feature/CH-43: 분실물 게시글 기능

### DIFF
--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepositoryImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepositoryImpl.java
@@ -40,7 +40,7 @@ public class LostFoundBoardRepositoryImpl implements LostFoundBoardRepositoryCus
                         lostFoundBoard.id,
                         lostFoundBoard.title,
                         lostFoundBoard.content,
-                        member.email,
+                        member.nickname,
                         JPAExpressions.select(comment.id.count()).from(comment).where(comment.lostFoundBoardId.eq(lostFoundBoard.id)),
                         lostFoundBoard.createdDate,
                         JPAExpressions.select(lostFoundBoardImage.imageFile.storeFileUrl).from(lostFoundBoardImage).where(lostFoundBoardImage.lostFoundBoardId.eq(lostFoundBoard.id)).limit(1),

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepositoryImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/domain/lost_found_board/LostFoundBoardRepositoryImpl.java
@@ -36,20 +36,28 @@ public class LostFoundBoardRepositoryImpl implements LostFoundBoardRepositoryCus
     @Override
     public Slice<LostFoundBoardListRespDto> getLostFoundBoardListBySlice(LostFoundBoardListReqDto lostFoundBoardListReqDto, Pageable pageable) {
         JPAQuery<LostFoundBoardListRespDto> query = queryFactory
-                .select(Projections.constructor(LostFoundBoardListRespDto.class,
+                .select(
+                        Projections.constructor(LostFoundBoardListRespDto.class,
                         lostFoundBoard.id,
                         lostFoundBoard.title,
                         lostFoundBoard.content,
                         member.nickname,
                         JPAExpressions.select(comment.id.count()).from(comment).where(comment.lostFoundBoardId.eq(lostFoundBoard.id)),
                         lostFoundBoard.createdDate,
-                        JPAExpressions.select(lostFoundBoardImage.imageFile.storeFileUrl).from(lostFoundBoardImage).where(lostFoundBoardImage.lostFoundBoardId.eq(lostFoundBoard.id)).limit(1),
+                        JPAExpressions.select(lostFoundBoardImage.imageFile.storeFileUrl).from(lostFoundBoardImage)
+                            .where(
+                                lostFoundBoardImage.id.eq(
+                                    JPAExpressions
+                                        .select(lostFoundBoardImage.id.max())
+                                        .from(lostFoundBoardImage)
+                                        .where(lostFoundBoardImage.lostFoundBoardId.eq(lostFoundBoard.id))
+                                )
+                            ),
                         lostFoundBoard.lostFoundEnum
                 ))
                 .from(lostFoundBoard)
-                .leftJoin(lostFoundBoard.waterPlace, waterPlace)
-                .join(member).on(lostFoundBoard.member.id.eq(member.id))
-                .groupBy(lostFoundBoard.id);
+                .join(lostFoundBoard.waterPlace, waterPlace)
+                .join(lostFoundBoard.member, member);
 
         BooleanBuilder booleanBuilder = new BooleanBuilder();
 

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/dto/lost_found_board/LostFoundBoardRespDto.java
@@ -38,6 +38,7 @@ public class LostFoundBoardRespDto {
         private String title;
         private String content;
         private String author;
+        private Long waterPlaceId;
         private String waterPlaceName;
         private String waterPlaceAddress;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -54,6 +55,7 @@ public class LostFoundBoardRespDto {
                     .title(lostFoundBoard.getTitle())
                     .content(lostFoundBoard.getContent())
                     .author(lostFoundBoard.getMember().getNickname())
+                    .waterPlaceId(lostFoundBoard.getWaterPlace().getId())
                     .waterPlaceName(lostFoundBoard.getWaterPlace().getWaterPlaceName())
                     .waterPlaceAddress(lostFoundBoard.getWaterPlace().getAddress())
                     .postCreateAt(lostFoundBoard.getCreatedDate())

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/service/page/PageServiceImpl.java
@@ -170,8 +170,9 @@ public class PageServiceImpl implements PageService{
 
         LostFoundBoard foundLostFoundBoard = findLostFoundBoardByIdWithMemberOrElseThrowEx(lostFoundBoardRepository, lostFoundBoardId);
 
-        boolean isMyBoard = member != null && isMyBoard(foundLostFoundBoard, member.getId());
-        List<CommentDetailRespDto> commentDetails = findCommentDetails(lostFoundBoardId, member != null ? member.getEmail() : null);
+        Long memberId = member != null ? member.getId() : null;
+        boolean isMyBoard = isMyBoard(foundLostFoundBoard, memberId);
+        List<CommentDetailRespDto> commentDetails = findCommentDetails(lostFoundBoardId, memberId);
         List<String> imageUrls = lostFoundBoardImageRepository.findImageByLostFoundBoardId(lostFoundBoardId);
         long commentCount = commentRepository.countByLostFoundBoardId(lostFoundBoardId);
 
@@ -182,19 +183,15 @@ public class PageServiceImpl implements PageService{
         return lostFoundBoard.getMember().getId().equals(memberId);
     }
 
-    private List<CommentDetailRespDto> findCommentDetails(long lostFoundBoardId, String memberEmail) {
+    private List<CommentDetailRespDto> findCommentDetails(long lostFoundBoardId, Long memberId) {
         return commentRepository.findCommentByLostFoundBoardIdFetchJoinMember(lostFoundBoardId)
                 .stream()
                 .map(c -> {
                     Member member = c.getMember();
-                    boolean isMyComment = memberEmail != null && isMyCommentByMemberEmail(memberEmail, member);
+                    boolean isMyComment = member.getId().equals(memberId);
                     String storeFileUrl = member.getImageFile() != null ? member.getImageFile().getStoreFileUrl() : null;
                     return new CommentDetailRespDto(c.getId(), member.getNickname(), c.getContent(), c.getCreatedDate(), isMyComment, storeFileUrl);
                 })
                 .collect(Collectors.toList());
-    }
-
-    private boolean isMyCommentByMemberEmail(String memberEmail, Member member) {
-        return (memberEmail.equals(member.getEmail()));
     }
 }

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/CommentApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/CommentApiController.java
@@ -20,7 +20,7 @@ import static kr.ac.kumoh.illdang100.tovalley.dto.comment.CommentRespDto.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class CommentController {
+public class CommentApiController {
     private final CommentService commentService;
 
     @PostMapping(value = "/auth/lostItem/{lostFoundBoardId}/comment")

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardApiController.java
@@ -32,7 +32,7 @@ import static kr.ac.kumoh.illdang100.tovalley.util.ImageUtil.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class LostFoundBoardController {
+public class LostFoundBoardApiController {
     private final LostFoundBoardService lostFoundBoardService;
     private final LostFoundBoardImageService lostFoundBoardImageService;
     private final S3Service s3Service;

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/LostFoundBoardController.java
@@ -76,7 +76,7 @@ public class LostFoundBoardController {
 
     @PatchMapping(value = "/auth/lostItem/{lostFoundBoardId}")
     public ResponseEntity<?> updateResolvedStatus(@PathVariable(value = "lostFoundBoardId")Long lostFoundBoardId,
-                                                  @RequestParam(value = "status") Boolean isResolved,
+                                                  @RequestParam Boolean isResolved,
                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         lostFoundBoardService.updateResolvedStatus(lostFoundBoardId, isResolved, principalDetails.getMember().getId());

--- a/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
+++ b/tovalley-server/src/main/java/kr/ac/kumoh/illdang100/tovalley/web/api/PageApiController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardRespDto.*;
@@ -85,7 +87,7 @@ public class PageApiController {
                                                      @CookieValue(value = JwtVO.ACCESS_TOKEN, required = false) String accessToken) {
         PrincipalDetails principalDetails = null;
         if (accessToken != null) {
-            String token = accessToken.substring(7); // TOKEN_PREFIX 제외한 토큰값
+            String token = URLDecoder.decode(accessToken, StandardCharsets.UTF_8).replace(JwtVO.TOKEN_PREFIX, "");
             principalDetails = jwtProcess.verify(token);
         }
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/CommentApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/CommentApiControllerTest.java
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Sql("classpath:db/teardown.sql")
-class CommentControllerTest extends DummyObject {
+class CommentApiControllerTest extends DummyObject {
     @Autowired
     private MockMvc mvc;
 

--- a/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/LostFoundBoardApiControllerTest.java
+++ b/tovalley-server/src/test/java/kr/ac/kumoh/illdang100/tovalley/web/page/LostFoundBoardApiControllerTest.java
@@ -1,4 +1,4 @@
-package kr.ac.kumoh.illdang100.tovalley.web;
+package kr.ac.kumoh.illdang100.tovalley.web.page;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.kumoh.illdang100.tovalley.domain.comment.CommentRepository;
@@ -18,19 +18,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import javax.persistence.EntityManager;
 import javax.servlet.http.Cookie;
 
-import static kr.ac.kumoh.illdang100.tovalley.dto.lost_found_board.LostFoundBoardReqDto.LostFoundBoardSaveReqDto;
 import static kr.ac.kumoh.illdang100.tovalley.util.TokenUtil.createTestAccessToken;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -38,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Sql("classpath:db/teardown.sql")
-class LostFoundBoardControllerTest extends DummyObject {
+class LostFoundBoardApiControllerTest extends DummyObject {
     @Autowired
     private MockMvc mvc;
 
@@ -72,31 +70,86 @@ class LostFoundBoardControllerTest extends DummyObject {
     }
 
     @Test
-    @DisplayName(value = "분실물 게시글 등록")
-    void saveLostFoundBoard() throws Exception {
+    @DisplayName(value = "기본 파라미터 - 카테고리, 물놀이 장소 아이디 1개, 검색어, 해결 완료 여부")
+    void getLostFoundBoardList() throws Exception {
         // given
-        Long waterPlaceId = 1L;
-        LostFoundBoardSaveReqDto lostFoundBoardSaveReqDto = new LostFoundBoardSaveReqDto("LOST", waterPlaceId, "잃어버림", "지갑 잃어버렸어요", null);
-
-        MockMultipartFile file1 = new MockMultipartFile("postImage", "image1.jpg", "image/jpeg", "some image".getBytes());
-        MockMultipartFile file2 = new MockMultipartFile("postImage", "image2.jpg", "image/jpeg", "some image".getBytes());
+        long waterPlaceId = 1L;
 
         // when
-        ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders.multipart("/api/auth/lostItem")
-                        .file(file1)
-                        .file(file2)
-                        .param("category", lostFoundBoardSaveReqDto.getCategory())
-                        .param("waterPlaceId", lostFoundBoardSaveReqDto.getWaterPlaceId().toString())
-                        .param("title", lostFoundBoardSaveReqDto.getTitle())
-                        .param("content", lostFoundBoardSaveReqDto.getContent())
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
-        );
+        ResultActions resultActions = mvc.perform(get("/api/lostItem?" + "category=LOST&waterPlaceId=" + waterPlaceId + "&searchWord=지갑&isResolved=false")
+                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
 
         // then
         resultActions
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName(value = "물놀이 장소 아이디 2개")
+    void getLostFoundBoardList_valleys() throws Exception {
+        // given
+        long waterPlaceId1 = 1L;
+        long waterPlaceId2 = 2L;
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/lostItem?" + "category=LOST&waterPlaceId=" + waterPlaceId1 + "&waterPlaceId=" + waterPlaceId2 + "&searchWord=지갑&isResolved=false")
+                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName(value = "카테고리 형식 에러")
+    void getLostFoundBoardList_category_error() throws Exception {
+        // given
+        long waterPlaceId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/lostItem?category=error&" + "waterPlaceId" + waterPlaceId + "&searchWord=지갑&isResolved=false")
+                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName(value = "파라미터 생략 - 물놀이 장소 아이디")
+    void getLostFoundBoardList_noPram() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/lostItem?category=LOST&&searchWord=지갑&isResolved=false")
+                .cookie(new Cookie(JwtVO.ACCESS_TOKEN, accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName(value = "분실물 게시글 상세 - 로그인하지 않은 사용자")
+    void getLostFoundBoardDetails_noAccessToken() throws Exception {
+        // given
+        Long lostFoundBoardId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/lostItem/" + lostFoundBoardId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
     }
 
@@ -115,7 +168,9 @@ class LostFoundBoardControllerTest extends DummyObject {
         lostFoundBoardRepository.save(newMockLostFoundBoard(4L, "폰 잃어버리신 분", "갤럭시S20", member, true, LostFoundEnum.FOUND, waterPlace2));
 
         commentRepository.save(newMockComment(1L, 1L, member));
+
         commentRepository.save(newMockComment(2L, 1L, member));
+
 
         em.clear();
     }


### PR DESCRIPTION
- 게시글 상세 페이지 조회 시 token 추출 방식 변경 (substring 대신 replace 사용)
- 게시글 조회 시 이메일 대신 닉네임 응답으로 보내줌
- 분실물 커뮤니티 해결완료 상태 변경 컨트롤러에서 파라미터명 변경
- Comment, LostFoundBoard 컨트롤러명 변경
- 분실문 커뮤니티 상세 페이지 조회 시 응답에 물놀이장소 아이디 추가
- 내가 쓴 댓글 구분 오류 해결
- 분실물 커뮤니티 조회 에러 해결 (querydsl에서 limit 누락되는 이슈로 인한 에러)